### PR TITLE
feat: support raw png buffer in matcher

### DIFF
--- a/.changeset/support-raw-png-buffer.md
+++ b/.changeset/support-raw-png-buffer.md
@@ -1,0 +1,10 @@
+---
+"@blazediff/matcher": minor
+---
+
+Support raw PNG Buffer input in toMatchImageSnapshot()
+
+- Add support for passing raw PNG Buffers directly (like `canvas.toBuffer('png')`)
+- Raw PNG buffers are automatically decoded to extract dimensions
+- New `isRawPngBuffer()` type guard exported for detecting raw PNG input
+- Fix: `updateSnapshots: 'all'` now only updates when images actually differ (skips identical snapshots)

--- a/packages/matcher/src/index.ts
+++ b/packages/matcher/src/index.ts
@@ -11,6 +11,7 @@ export {
 	fileExists,
 	isFilePath,
 	isImageBuffer,
+	isRawPngBuffer,
 	loadPNG,
 	normalizeImageInput,
 	savePNG,

--- a/packages/matcher/src/types.ts
+++ b/packages/matcher/src/types.ts
@@ -15,10 +15,12 @@ export type ComparisonMethod =
 export type SnapshotStatus = "added" | "matched" | "updated" | "failed";
 
 /**
- * Image input - either a file path or a buffer with dimensions
+ * Image input - file path, raw PNG buffer, or buffer with dimensions
  */
 export type ImageInput =
 	| string
+	| Buffer
+	| Uint8Array
 	| {
 			data: Uint8Array | Uint8ClampedArray | Buffer;
 			width: number;


### PR DESCRIPTION
# Description

Support raw PNG Buffer input in toMatchImageSnapshot()

- Add support for passing raw PNG Buffers directly (like `canvas.toBuffer('png')`)
- Raw PNG buffers are automatically decoded to extract dimensions
- New `isRawPngBuffer()` type guard exported for detecting raw PNG input
- Fix: `updateSnapshots: 'all'` now only updates when images actually differ (skips identical snapshots)

Closes #29 