### PR TITLE
fix: force dark theme on docs (#61)

### DIFF
--- a/apps/website/components/landing/nextra-shell.tsx
+++ b/apps/website/components/landing/nextra-shell.tsx
@@ -37,6 +37,8 @@ export default async function NextraShell({
 			pageMap={await getPageMap()}
 			docsRepositoryBase="https://github.com/teimurjan/blazediff/tree/main/apps/website"
 			footer={footer}
+			darkMode={false}
+			nextThemes={{ forcedTheme: "dark" }}
 		>
 			<div className="max-w-7xl m-auto">{children}</div>
 		</Layout>


### PR DESCRIPTION
## What
Force the docs site to always render in dark mode and hide the theme switcher.

## Why
Closes #61. The site's CSS hardcodes a dark canvas + `color-scheme: dark`, but Nextra still let users flip to light mode, leaving dark gray text on a dark background — unreadable.

## How
Pass `nextThemes={{ forcedTheme: "dark" }}` and `darkMode={false}` to the Nextra `Layout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)