### PR TITLE
feat(core): extend native and wasm diff

### DIFF
--- a/.changeset/bright-wasps-compare.md
+++ b/.changeset/bright-wasps-compare.md
@@ -1,0 +1,6 @@
+---
+"@blazediff/core-native": patch
+"@blazediff/core-wasm": minor
+---
+
+Allow WebAssembly `diff` to return interpretation and diff output from one pass, and make native combined comparison write its requested output.

--- a/.changeset/calm-colors-shine.md
+++ b/.changeset/calm-colors-shine.md
@@ -1,0 +1,6 @@
+---
+"@blazediff/core-native": minor
+"@blazediff/core-wasm": minor
+---
+
+Add `diffColorAlt` for coloring darkening differences in native and WebAssembly diff output.

--- a/apps/website/app/apis/core-native/page.mdx
+++ b/apps/website/app/apis/core-native/page.mdx
@@ -59,7 +59,8 @@ Compares two images (PNG, JPEG, or QOI) and generates a diff image. Format is au
 | `threshold`        | `number`  | `0.1`   | Color difference threshold (0.0-1.0). Lower = more strict |
 | `antialiasing`     | `boolean` | `false` | Enable anti-aliasing detection                           |
 | `diffMask`         | `boolean` | `false` | Output only differences with transparent background      |
-| `interpret`        | `boolean` | `false` | Run structured interpretation (region detection + classification) |
+| `diffColorAlt`     | `[number, number, number]` | diff color | Alternative RGB color for darkening differences |
+| `interpret`        | `boolean` | `false` | Generate the diff image and structured interpretation in one pass |
 
 #### Return Types
 
@@ -71,7 +72,7 @@ type BlazeDiffResult =
   | { match: false; reason: "file-not-exists"; file: string };
 ```
 
-When `interpret: true`, the result includes an `interpretation` field with structured analysis.
+When `interpret: true`, the requested diff output is written and the result includes an `interpretation` field from the same diff pass.
 
 <Callout type="info">
   **Threshold Guidelines:**
@@ -144,6 +145,7 @@ Options:
   -t, --threshold <THRESHOLD>  Color difference threshold (0.0-1.0) [default: 0.1]
   -a, --antialiasing           Enable anti-aliasing detection
       --diff-mask              Output only differences (transparent background)
+      --diff-color-alt <R,G,B> Alternative RGB color for darkening differences
   -c, --compression <LEVEL>    PNG compression level (0-9, 0=fastest, 9=smallest) [default: 0]
   -q, --quality <QUALITY>      JPEG quality (1-100) [default: 90]
       --interpret              Run structured interpretation after diff

--- a/apps/website/app/apis/core-wasm/page.mdx
+++ b/apps/website/app/apis/core-wasm/page.mdx
@@ -91,7 +91,7 @@ await initBlazediff(readFileSync(wasmPath));
 
 ### `diff(a, b, width, height, output?, options?)`
 
-Compares two RGBA pixel buffers and returns the number of differing pixels.
+Compares two RGBA pixel buffers and returns the number of differing pixels. Set `interpret: true` to return structured interpretation while producing the diff output in the same pass.
 
 #### Parameters
 
@@ -102,7 +102,7 @@ Compares two RGBA pixel buffers and returns the number of differing pixels.
 | `width`   | `number`              | Image width in pixels                                    |
 | `height`  | `number`              | Image height in pixels                                   |
 | `output`  | `Uint8Array \| undefined` | Optional diff visualization output (same length). Written in place |
-| `options` | `DiffOptions`         | Comparison options (optional)                            |
+| `options` | `DiffOptions \| InterpretedDiffOptions` | Comparison options (optional)                  |
 
 ##### Options
 
@@ -111,10 +111,37 @@ Compares two RGBA pixel buffers and returns the number of differing pixels.
 | `threshold`  | `number`  | `0.1`   | Color difference threshold (0.0-1.0). Lower = more strict |
 | `includeAA`  | `boolean` | `false` | Count anti-aliased pixels as differences                 |
 | `diffMask`   | `boolean` | `false` | Render diff with transparent background instead of grayscale base |
+| `diffColorAlt` | `[number, number, number]` | diff color | Alternative RGB color for darkening differences |
+| `interpret` | `boolean` | `false` | Return structured interpretation from the same diff pass |
 
 <Callout type="info">
   **Threshold Guidelines:** `0.0` exact match · `0.05` strict · `0.1` default · `0.2` lenient
 </Callout>
+
+With `interpret: true`, `diff()` returns a `DiffResult` instead of a pixel count:
+
+```typescript
+const result = await diff(a, b, width, height, output, {
+  diffColorAlt: [0, 128, 255],
+  interpret: true,
+});
+```
+
+```typescript
+type DiffResult =
+  | { match: true; interpretation: InterpretResult }
+  | {
+      match: false;
+      reason: 'pixel-diff';
+      diffCount: number;
+      diffPercentage: number;
+      interpretation: InterpretResult;
+    };
+```
+
+### `interpret(a, b, width, height, options?)`
+
+Returns structured change regions without retaining a diff visualization. It is a convenience wrapper over `diff()` with `interpret: true`.
 
 ## Usage
 

--- a/crates/blazediff/src/interpret/mod.rs
+++ b/crates/blazediff/src/interpret/mod.rs
@@ -39,6 +39,10 @@ use types::{ChangeRegion, ChangeType, InterpretResult};
 /// throwing away genuine edits.
 const REFINE_DELTA_FLOOR_SQ: f32 = 100.0;
 
+const MASK_DIFF_COLOR: [u8; 3] = [255, 0, 0];
+const MASK_DIFF_COLOR_ALT: [u8; 3] = [0, 0, 255];
+const MASK_AA_COLOR: [u8; 3] = [255, 255, 0];
+
 /// Refine a coarse mask down to the actually-changed pixels inside the given
 /// bboxes. Pixels marked true in `input_mask` but with a tiny YIQ delta between
 /// `img1` and `img2` are dropped. Used by classifier-only paths so callers can
@@ -165,26 +169,45 @@ pub fn classify_regions(
     regions
 }
 
-/// Run a diff and interpret the results into structured regions with spatial positions,
-/// severity, color deltas, gradient scoring, and semantic interpretation.
-pub fn interpret(
+fn recolor_output(output: &mut Image, options: &DiffOptions) {
+    let diff_color_alt = options.diff_color_alt.unwrap_or(options.diff_color);
+
+    for pixel in output.data.chunks_exact_mut(4) {
+        let color = match [pixel[0], pixel[1], pixel[2]] {
+            MASK_DIFF_COLOR => options.diff_color,
+            MASK_DIFF_COLOR_ALT => diff_color_alt,
+            MASK_AA_COLOR => options.aa_color,
+            _ => continue,
+        };
+        pixel[..3].copy_from_slice(&color);
+    }
+}
+
+/// Run a diff once, optionally retain its visualization, and interpret the
+/// results into structured regions.
+pub fn interpret_with_output(
     img1: &Image,
     img2: &Image,
+    mut output: Option<&mut Image>,
     options: &DiffOptions,
 ) -> Result<InterpretResult, DiffError> {
     let width = img1.width;
     let height = img1.height;
     let total_pixels = (width * height) as f64;
 
-    let mut output = Image::new(width, height);
-    // Force alpha=0 so unchanged pixels are pure grayscale - the change mask
-    // relies on R!=G||R!=B to detect changed pixels, and any original-color
-    // bleed would cause false positives.
+    let retain_output = output.is_some();
+    let mut internal_output = Image::new_uninit(width, height);
+    let diff_output = output.as_deref_mut().unwrap_or(&mut internal_output);
+
+    // Stable non-grayscale marker colors keep mask extraction independent of
+    // caller-selected colors, including grayscale alternatives.
     let mask_options = DiffOptions {
-        alpha: 0.0,
-        ..*options
+        aa_color: MASK_AA_COLOR,
+        diff_color: MASK_DIFF_COLOR,
+        diff_color_alt: Some(MASK_DIFF_COLOR_ALT),
+        ..options.clone()
     };
-    let diff_result = diff(img1, img2, Some(&mut output), &mask_options)?;
+    let diff_result = diff(img1, img2, Some(diff_output), &mask_options)?;
 
     if diff_result.identical {
         return Ok(InterpretResult {
@@ -199,7 +222,10 @@ pub fn interpret(
         });
     }
 
-    let mask = extract_change_mask(&output.data, width, height);
+    let mask = extract_change_mask(&diff_output.data, width, height);
+    if retain_output {
+        recolor_output(diff_output, options);
+    }
     let components = detect_regions(&mask, width, height);
     let mut regions: Vec<ChangeRegion> = components
         .into_iter()
@@ -234,6 +260,16 @@ pub fn interpret(
     })
 }
 
+/// Run a diff and interpret the results into structured regions with spatial positions,
+/// severity, color deltas, gradient scoring, and semantic interpretation.
+pub fn interpret(
+    img1: &Image,
+    img2: &Image,
+    options: &DiffOptions,
+) -> Result<InterpretResult, DiffError> {
+    interpret_with_output(img1, img2, None, options)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,6 +301,44 @@ mod tests {
 
         assert_eq!(result.total_regions, 0);
         assert!(result.regions.is_empty());
+    }
+
+    #[test]
+    fn test_interpret_with_output_matches_diff() {
+        let img1 = make_solid_image(32, 32, 200, 200, 200);
+        let img2 = make_solid_image(32, 32, 50, 50, 50);
+        let options = DiffOptions {
+            include_aa: true,
+            diff_color_alt: Some([0, 128, 255]),
+            ..Default::default()
+        };
+        let mut expected = Image::new(32, 32);
+        let diff_result = diff(&img1, &img2, Some(&mut expected), &options).unwrap();
+        let mut actual = Image::new(32, 32);
+
+        let interpretation =
+            interpret_with_output(&img1, &img2, Some(&mut actual), &options).unwrap();
+
+        assert_eq!(interpretation.diff_count, diff_result.diff_count);
+        assert_eq!(actual.data, expected.data);
+    }
+
+    #[test]
+    fn test_interpret_with_grayscale_alt_color_keeps_regions() {
+        let img1 = make_solid_image(32, 32, 200, 200, 200);
+        let img2 = make_solid_image(32, 32, 50, 50, 50);
+        let options = DiffOptions {
+            include_aa: true,
+            diff_color_alt: Some([32, 32, 32]),
+            ..Default::default()
+        };
+        let mut output = Image::new(32, 32);
+
+        let result = interpret_with_output(&img1, &img2, Some(&mut output), &options).unwrap();
+
+        assert_eq!(result.diff_count, 32 * 32);
+        assert!(result.total_regions > 0);
+        assert_eq!(&output.data[..4], &[32, 32, 32, 255]);
     }
 
     #[test]

--- a/crates/blazediff/src/main.rs
+++ b/crates/blazediff/src/main.rs
@@ -11,8 +11,8 @@
 //!   2 - Error
 
 use blazediff::{
-    diff, interpret::interpret, load_jpeg, load_jpegs, load_png, load_pngs, load_qoi, load_qois,
-    save_jpeg, save_png_with_compression, save_qoi, DiffError, DiffOptions, Image,
+    diff, interpret::interpret_with_output, load_jpeg, load_jpegs, load_png, load_pngs, load_qoi,
+    load_qois, save_jpeg, save_png_with_compression, save_qoi, DiffError, DiffOptions, Image,
 };
 use clap::Parser;
 use rayon::prelude::*;
@@ -50,6 +50,10 @@ struct Args {
     #[arg(long)]
     diff_mask: bool,
 
+    /// Alternative RGB color for darkening differences (r,g,b)
+    #[arg(long, value_parser = parse_rgb)]
+    diff_color_alt: Option<[u8; 3]>,
+
     /// Output format (json or text)
     #[arg(long, default_value = "json")]
     output_format: String,
@@ -65,6 +69,22 @@ struct Args {
     /// Run structured interpretation after raw pixel diff
     #[arg(long)]
     interpret: bool,
+}
+
+fn parse_rgb(value: &str) -> Result<[u8; 3], String> {
+    let channels = value
+        .split(',')
+        .map(str::trim)
+        .map(|channel| {
+            channel
+                .parse::<u8>()
+                .map_err(|_| format!("invalid RGB channel: {channel}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    channels
+        .try_into()
+        .map_err(|_| "RGB color must contain exactly three channels".to_string())
 }
 
 /// Supported image formats
@@ -188,6 +208,7 @@ fn main() -> ExitCode {
         threshold: args.threshold,
         include_aa: !args.antialiasing,
         diff_mask: args.diff_mask,
+        diff_color_alt: args.diff_color_alt,
         compression: args.compression,
         ..Default::default()
     };
@@ -229,7 +250,12 @@ fn main() -> ExitCode {
 }
 
 fn run_interpret(args: &Args, img1: &Image, img2: &Image, options: &DiffOptions) -> ExitCode {
-    let result = match interpret(img1, img2, options) {
+    let mut output_image = if args.output.is_some() {
+        Some(Image::new_uninit(img1.width, img1.height))
+    } else {
+        None
+    };
+    let result = match interpret_with_output(img1, img2, output_image.as_mut(), options) {
         Ok(r) => r,
         Err(e) => {
             output_error(args, &format!("Interpret failed: {e}"));
@@ -237,13 +263,22 @@ fn run_interpret(args: &Args, img1: &Image, img2: &Image, options: &DiffOptions)
         }
     };
 
+    if result.diff_count > 0 {
+        if let (Some(ref output_path), Some(ref output)) = (&args.output, &output_image) {
+            if let Err(e) = save_image(output, output_path, args) {
+                output_error(args, &format!("Failed to save {output_path}: {e}"));
+                return ExitCode::from(2);
+            }
+        }
+    }
+
     if args.output_format == "json" {
         println!("{}", serde_json::to_string_pretty(&result).unwrap());
     } else {
         println!("{}", result.summary);
     }
 
-    if result.total_regions == 0 {
+    if result.diff_count == 0 {
         ExitCode::from(0)
     } else {
         ExitCode::from(1)

--- a/crates/blazediff/src/napi.rs
+++ b/crates/blazediff/src/napi.rs
@@ -4,8 +4,11 @@
 //! without spawning child processes.
 
 use crate::{
-    diff, interpret::interpret, interpret::types as itypes, load_jpeg, load_jpegs, load_png,
-    load_pngs, save_jpeg, save_png_with_compression, DiffError, DiffOptions, Image,
+    diff,
+    interpret::types as itypes,
+    interpret::{interpret, interpret_with_output},
+    load_jpeg, load_jpegs, load_png, load_pngs, save_jpeg, save_png_with_compression, DiffError,
+    DiffOptions, Image,
 };
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -94,6 +97,8 @@ pub struct NapiDiffOptions {
     pub antialiasing: Option<bool>,
     /// Output only differences with transparent background
     pub diff_mask: Option<bool>,
+    /// Alternative RGB color for darkening differences
+    pub diff_color_alt: Option<Vec<u8>>,
     /// PNG compression level (0-9, 0=fastest, 9=smallest). Default: 0
     pub compression: Option<u8>,
     /// JPEG quality (1-100). Default: 90
@@ -117,6 +122,19 @@ pub struct NapiDiffResult {
     pub interpretation: Option<NapiInterpretResult>,
 }
 
+fn optional_rgb(value: Option<Vec<u8>>, label: &str) -> Result<Option<[u8; 3]>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    match value.as_slice() {
+        [r, g, b] => Ok(Some([*r, *g, *b])),
+        _ => Err(Error::new(
+            Status::InvalidArg,
+            format!("{}: expected 3 channels, got {}", label, value.len()),
+        )),
+    }
+}
+
 /// Compare two images and optionally generate a diff image.
 ///
 /// Returns a result object with match status and diff details.
@@ -131,6 +149,7 @@ pub fn compare(
         threshold: None,
         antialiasing: None,
         diff_mask: None,
+        diff_color_alt: None,
         compression: None,
         quality: None,
         interpret: None,
@@ -139,6 +158,7 @@ pub fn compare(
     let threshold = opts.threshold.unwrap_or(0.1);
     let antialiasing = opts.antialiasing.unwrap_or(false);
     let diff_mask = opts.diff_mask.unwrap_or(false);
+    let diff_color_alt = optional_rgb(opts.diff_color_alt, "diff_color_alt")?;
     let compression = opts.compression.unwrap_or(0);
     let quality = opts.quality.unwrap_or(90);
     let run_interpret = opts.interpret.unwrap_or(false);
@@ -166,16 +186,33 @@ pub fn compare(
         threshold,
         include_aa: !antialiasing,
         diff_mask,
+        diff_color_alt,
         compression,
         ..Default::default()
     };
 
-    // Interpret mode: run structured analysis and return early
+    // Interpret mode: generate the visualization and structured analysis in one pass.
     if run_interpret {
-        let result = interpret(&img1, &img2, &diff_options)
+        let mut output_image = if diff_output.is_some() {
+            Some(Image::new_uninit(img1.width, img1.height))
+        } else {
+            None
+        };
+        let result = interpret_with_output(&img1, &img2, output_image.as_mut(), &diff_options)
             .map_err(|e| Error::new(Status::GenericFailure, format!("Interpret failed: {}", e)))?;
 
-        let is_identical = result.total_regions == 0;
+        let is_identical = result.diff_count == 0;
+        if !is_identical {
+            if let (Some(ref output_path), Some(ref output)) = (&diff_output, &output_image) {
+                save_image(output, output_path, compression, quality).map_err(|e| {
+                    Error::new(
+                        Status::GenericFailure,
+                        format!("Failed to save diff: {}", e),
+                    )
+                })?;
+            }
+        }
+
         let diff_count = result.diff_count;
         let diff_percentage = result.diff_percentage;
         let regions: Vec<NapiChangeRegion> = result.regions.iter().map(convert_region).collect();

--- a/crates/blazediff/src/wasm.rs
+++ b/crates/blazediff/src/wasm.rs
@@ -33,6 +33,41 @@ fn image_from_slice(rgba: &[u8], width: u32, height: u32, label: &str) -> Result
     })
 }
 
+fn optional_rgb(value: Option<Vec<u8>>, label: &str) -> Result<Option<[u8; 3]>, JsError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    match value.as_slice() {
+        [r, g, b] => Ok(Some([*r, *g, *b])),
+        _ => Err(JsError::new(&format!(
+            "{}: expected 3 channels, got {}",
+            label,
+            value.len()
+        ))),
+    }
+}
+
+fn copy_output(
+    target: Option<js_sys::Uint8Array>,
+    output: Option<&Image>,
+    has_diff: bool,
+) -> Result<(), JsError> {
+    let (Some(target), Some(output)) = (target, output) else {
+        return Ok(());
+    };
+    if target.length() as usize != output.data.len() {
+        return Err(JsError::new(&format!(
+            "out_diff: expected {} bytes, got {}",
+            output.data.len(),
+            target.length()
+        )));
+    }
+    if has_diff {
+        target.copy_from(&output.data);
+    }
+    Ok(())
+}
+
 /// Diff two RGBA buffers. Returns the count of differing pixels.
 ///
 /// If `out_diff` is provided, the visualization is written into it in-place
@@ -47,6 +82,7 @@ pub fn diff_rgba(
     threshold: f64,
     include_aa: bool,
     diff_mask: bool,
+    diff_color_alt: Option<Vec<u8>>,
     out_diff: Option<js_sys::Uint8Array>,
 ) -> Result<u32, JsError> {
     let img1 = image_from_slice(rgba_a, width, height, "rgba_a")?;
@@ -56,6 +92,7 @@ pub fn diff_rgba(
         threshold,
         include_aa,
         diff_mask,
+        diff_color_alt: optional_rgb(diff_color_alt, "diff_color_alt")?,
         ..Default::default()
     };
 
@@ -64,22 +101,8 @@ pub fn diff_rgba(
     let result = diff(&img1, &img2, output_image.as_mut(), &opts)
         .map_err(|e| JsError::new(&e.to_string()))?;
 
-    if let (Some(target), Some(out)) = (out_diff, output_image.as_ref()) {
-        if (target.length() as usize) != out.data.len() {
-            return Err(JsError::new(&format!(
-                "out_diff: expected {} bytes, got {}",
-                out.data.len(),
-                target.length()
-            )));
-        }
-        // On identical the diff intentionally leaves the output buffer
-        // unwritten (the gray-fill is purely cosmetic and is skipped for
-        // performance). Don't copy that uninitialized-feeling memory back
-        // to the caller - preserve whatever they passed in.
-        if !result.identical {
-            target.copy_from(&out.data);
-        }
-    }
+    // On identical the diff intentionally leaves the output buffer unwritten.
+    copy_output(out_diff, output_image.as_ref(), !result.identical)?;
 
     Ok(result.diff_count)
 }
@@ -97,6 +120,9 @@ pub fn interpret_rgba(
     height: u32,
     threshold: f64,
     include_aa: bool,
+    diff_mask: bool,
+    diff_color_alt: Option<Vec<u8>>,
+    out_diff: Option<js_sys::Uint8Array>,
 ) -> Result<JsValue, JsError> {
     let img1 = image_from_slice(rgba_a, width, height, "rgba_a")?;
     let img2 = image_from_slice(rgba_b, width, height, "rgba_b")?;
@@ -104,11 +130,16 @@ pub fn interpret_rgba(
     let opts = DiffOptions {
         threshold,
         include_aa,
+        diff_mask,
+        diff_color_alt: optional_rgb(diff_color_alt, "diff_color_alt")?,
         ..Default::default()
     };
 
-    let result = crate::interpret::interpret(&img1, &img2, &opts)
-        .map_err(|e| JsError::new(&e.to_string()))?;
+    let mut output_image = out_diff.as_ref().map(|_| Image::new_uninit(width, height));
+    let result =
+        crate::interpret::interpret_with_output(&img1, &img2, output_image.as_mut(), &opts)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+    copy_output(out_diff, output_image.as_ref(), result.diff_count > 0)?;
 
     serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
 }

--- a/packages/core-native/README.md
+++ b/packages/core-native/README.md
@@ -109,10 +109,16 @@ Compare two images (PNG or JPEG) and generate a diff image. Format is auto-detec
     <td>Output only differences with transparent background</td>
   </tr>
   <tr>
+    <td><code>diffColorAlt</code></td>
+    <td>[number, number, number]</td>
+    <td>diff color</td>
+    <td>Alternative RGB color for darkening differences</td>
+  </tr>
+  <tr>
     <td><code>interpret</code></td>
     <td>boolean</td>
     <td>false</td>
-    <td>Run structured interpretation after diff - adds <code>interpretation</code> to the result with detected change regions, classification, and a human-readable summary</td>
+    <td>Generate the diff image and structured interpretation in one pass, adding <code>interpretation</code> to the result</td>
   </tr>
 </table>
 
@@ -272,9 +278,11 @@ Options:
   -t, --threshold <THRESHOLD>  Color difference threshold (0.0-1.0) [default: 0.1]
   -a, --antialiasing           Enable anti-aliasing detection
       --diff-mask              Output only differences (transparent background)
+      --diff-color-alt <R,G,B> Alternative RGB color for darkening differences
   -c, --compression <LEVEL>    PNG compression level (0-9, 0=fastest, 9=smallest) [default: 0]
   -q, --quality <QUALITY>      JPEG quality (1-100) [default: 90]
       --output-format <FORMAT> Output format (json or text) [default: json]
+      --interpret              Generate diff output and structured interpretation
   -h, --help                   Print help
   -V, --version                Print version
 ```

--- a/packages/core-native/src/index.test.ts
+++ b/packages/core-native/src/index.test.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
@@ -75,6 +77,112 @@ describe("compare", () => {
 				expect(strictResult.diffCount).toBeGreaterThanOrEqual(
 					lenientResult.diffCount,
 				);
+			}
+		});
+
+		it("should apply diffColorAlt to darkening changes", async () => {
+			const path1 = join(FIXTURES_PATH, "pixelmatch/1a.png");
+			const path2 = join(FIXTURES_PATH, "pixelmatch/1b.png");
+			const tempDir = await mkdtemp(join(tmpdir(), "blazediff-native-alt-"));
+
+			try {
+				const directions = [
+					[path1, path2, "forward"],
+					[path2, path1, "reverse"],
+				] as const;
+				const outputsDiffer = await Promise.all(
+					directions.map(async ([base, actual, name]) => {
+						const defaultOutput = join(tempDir, `${name}-default.png`);
+						const altOutput = join(tempDir, `${name}-alt.png`);
+						await compare(base, actual, defaultOutput);
+						await compare(base, actual, altOutput, {
+							diffColorAlt: [0, 128, 255],
+						});
+						const [defaultBytes, altBytes] = await Promise.all([
+							readFile(defaultOutput),
+							readFile(altOutput),
+						]);
+						return !defaultBytes.equals(altBytes);
+					}),
+				);
+
+				expect(outputsDiffer.some(Boolean)).toBe(true);
+			} finally {
+				await rm(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		it("should reject invalid diffColorAlt channels", async () => {
+			const imagePath = join(FIXTURES_PATH, "same/1a.png");
+
+			await expect(
+				compare(imagePath, imagePath, undefined, {
+					diffColorAlt: [0, 256, 0],
+				}),
+			).rejects.toThrow("diffColorAlt must contain three integer RGB channels");
+		});
+
+		it("should write the same diff while returning interpretation", async () => {
+			const path1 = join(FIXTURES_PATH, "pixelmatch/1a.png");
+			const path2 = join(FIXTURES_PATH, "pixelmatch/1b.png");
+			const tempDir = await mkdtemp(
+				join(tmpdir(), "blazediff-native-combined-"),
+			);
+
+			try {
+				const standaloneOutput = join(tempDir, "standalone.png");
+				const combinedOutput = join(tempDir, "combined.png");
+				const options = {
+					diffColorAlt: [0, 128, 255] as [number, number, number],
+				};
+				await compare(path1, path2, standaloneOutput, options);
+				const result = await compare(path1, path2, combinedOutput, {
+					...options,
+					interpret: true,
+				});
+
+				expect(result.match).toBe(false);
+				if (!result.match && result.reason === "pixel-diff") {
+					expect(result.interpretation?.diffCount).toBe(result.diffCount);
+				}
+				const [standaloneBytes, combinedBytes] = await Promise.all([
+					readFile(standaloneOutput),
+					readFile(combinedOutput),
+				]);
+				expect(combinedBytes).toEqual(standaloneBytes);
+			} finally {
+				await rm(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		it("should support combined output in the CLI fallback", async () => {
+			const path1 = join(FIXTURES_PATH, "pixelmatch/1a.png");
+			const path2 = join(FIXTURES_PATH, "pixelmatch/1b.png");
+			const tempDir = await mkdtemp(join(tmpdir(), "blazediff-cli-combined-"));
+			const output = join(tempDir, "combined.png");
+
+			try {
+				let stdout = "";
+				try {
+					await execFileAsync(getBinaryPath(), [
+						path1,
+						path2,
+						output,
+						"--interpret",
+						"--diff-color-alt=0,128,255",
+						"--output-format=json",
+					]);
+				} catch (error) {
+					const failure = error as { code?: number; stdout?: string };
+					expect(failure.code).toBe(1);
+					stdout = failure.stdout ?? "";
+				}
+
+				const interpretation = JSON.parse(stdout) as { diffCount: number };
+				expect(interpretation.diffCount).toBeGreaterThan(0);
+				expect((await readFile(output)).length).toBeGreaterThan(0);
+			} finally {
+				await rm(tempDir, { recursive: true, force: true });
 			}
 		});
 	});

--- a/packages/core-native/src/index.ts
+++ b/packages/core-native/src/index.ts
@@ -15,6 +15,8 @@ export interface BlazeDiffOptions {
 	antialiasing?: boolean;
 	/** Output only differences with transparent background */
 	diffMask?: boolean;
+	/** Alternative RGB color for darkening differences. Default: diff color */
+	diffColorAlt?: [number, number, number];
 	/** PNG compression level (0-9, 0=fastest/largest, 9=slowest/smallest) */
 	compression?: number;
 	/** JPEG quality (1-100). Default: 90 */
@@ -56,6 +58,7 @@ interface NapiDiffOptions {
 	threshold?: number;
 	antialiasing?: boolean;
 	diffMask?: boolean;
+	diffColorAlt?: [number, number, number];
 	compression?: number;
 	quality?: number;
 	interpret?: boolean;
@@ -147,6 +150,23 @@ interface NativeBinding {
 		image2Path: string,
 		options: NapiInterpretOptions | null,
 	): InterpretResult;
+}
+
+function validateRgb(
+	color: [number, number, number] | undefined,
+): [number, number, number] | undefined {
+	if (!color) return undefined;
+	if (
+		color.length !== 3 ||
+		color.some(
+			(channel) => !Number.isInteger(channel) || channel < 0 || channel > 255,
+		)
+	) {
+		throw new RangeError(
+			"diffColorAlt must contain three integer RGB channels",
+		);
+	}
+	return color;
 }
 
 const PLATFORM_PACKAGES: Record<
@@ -269,6 +289,7 @@ function convertToNapiOptions(options?: BlazeDiffOptions): NapiDiffOptions {
 		threshold: options?.threshold,
 		antialiasing: options?.antialiasing,
 		diffMask: options?.diffMask,
+		diffColorAlt: validateRgb(options?.diffColorAlt),
 		compression: options?.compression,
 		quality: options?.quality,
 		interpret: options?.interpret,
@@ -346,13 +367,12 @@ function buildArgs(diffOutput?: string, options?: BlazeDiffOptions): string[] {
 	if (options.threshold !== undefined)
 		args.push(`--threshold=${options.threshold}`);
 	if (options.antialiasing) args.push("--antialiasing");
-	if (!useInterpret) {
-		if (options.diffMask) args.push("--diff-mask");
-		if (options.compression !== undefined)
-			args.push(`--compression=${options.compression}`);
-		if (options.quality !== undefined)
-			args.push(`--quality=${options.quality}`);
-	}
+	if (options.diffMask) args.push("--diff-mask");
+	const diffColorAlt = validateRgb(options.diffColorAlt);
+	if (diffColorAlt) args.push(`--diff-color-alt=${diffColorAlt.join(",")}`);
+	if (options.compression !== undefined)
+		args.push(`--compression=${options.compression}`);
+	if (options.quality !== undefined) args.push(`--quality=${options.quality}`);
 
 	return args;
 }

--- a/packages/core-wasm/README.md
+++ b/packages/core-wasm/README.md
@@ -103,7 +103,7 @@ Initializes the wasm module. Safe to call multiple times; subsequent calls retur
 
 ### `diff(a, b, width, height, output?, options?)`
 
-Compares two RGBA pixel buffers and returns the number of differing pixels.
+Compares two RGBA pixel buffers and returns the number of differing pixels. Set `interpret: true` to return structured interpretation while producing the diff output in the same pass.
 
 <table>
   <tr>
@@ -138,12 +138,12 @@ Compares two RGBA pixel buffers and returns the number of differing pixels.
   </tr>
   <tr>
     <td><code>options</code></td>
-    <td>DiffOptions</td>
+    <td>DiffOptions | InterpretedDiffOptions</td>
     <td>Comparison options (optional)</td>
   </tr>
 </table>
 
-**Returns:** `Promise<number>` (count of differing pixels)
+**Returns:** `Promise<number>` by default, or `Promise<DiffResult>` with `interpret: true`
 
 <table>
   <tr>
@@ -170,7 +170,46 @@ Compares two RGBA pixel buffers and returns the number of differing pixels.
     <td>false</td>
     <td>Render diff with transparent background instead of grayscale base</td>
   </tr>
+  <tr>
+    <td><code>diffColorAlt</code></td>
+    <td>[number, number, number]</td>
+    <td>diff color</td>
+    <td>Alternative RGB color for darkening differences</td>
+  </tr>
+  <tr>
+    <td><code>interpret</code></td>
+    <td>boolean</td>
+    <td>false</td>
+    <td>Return structured interpretation from the same diff pass</td>
+  </tr>
 </table>
+
+With `interpret: true`, `diff()` returns:
+
+```typescript
+type DiffResult =
+  | { match: true; interpretation: InterpretResult }
+  | {
+      match: false;
+      reason: 'pixel-diff';
+      diffCount: number;
+      diffPercentage: number;
+      interpretation: InterpretResult;
+    };
+```
+
+```typescript
+const result = await diff(a, b, width, height, output, {
+  diffColorAlt: [0, 128, 255],
+  interpret: true,
+});
+```
+
+### `interpret(a, b, width, height, options?)`
+
+Returns structured change regions without retaining a diff visualization. It is a convenience wrapper over `diff()` with `interpret: true`.
+
+**Returns:** `Promise<InterpretResult>`
 
 ## Usage
 

--- a/packages/core-wasm/src/index.test.ts
+++ b/packages/core-wasm/src/index.test.ts
@@ -33,6 +33,14 @@ function loadPNG(rel: string): {
 	};
 }
 
+function solidRgba(width: number, height: number, value: number): Uint8Array {
+	const pixels = new Uint8Array(width * height * 4);
+	for (let offset = 0; offset < pixels.length; offset += 4) {
+		pixels.set([value, value, value, 255], offset);
+	}
+	return pixels;
+}
+
 beforeAll(async () => {
 	const bytes = readFileSync(WASM_PATH);
 	await initBlazediff(bytes);
@@ -97,10 +105,81 @@ describe("diff() smoke", () => {
 		expect(out.some((v) => v !== 0)).toBe(true);
 	});
 
+	it("writes diffColorAlt for darkening changes", async () => {
+		const brighter = solidRgba(2, 2, 200);
+		const darker = solidRgba(2, 2, 50);
+		const out = new Uint8Array(brighter.length);
+
+		const count = await diff(brighter, darker, 2, 2, out, {
+			includeAA: true,
+			diffColorAlt: [0, 128, 255],
+		});
+
+		expect(count).toBe(4);
+		expect([...out.slice(0, 4)]).toEqual([0, 128, 255, 255]);
+	});
+
+	it("rejects invalid diffColorAlt channels", async () => {
+		const brighter = solidRgba(2, 2, 200);
+		const darker = solidRgba(2, 2, 50);
+
+		await expect(
+			diff(brighter, darker, 2, 2, undefined, {
+				diffColorAlt: [0, 256, 0],
+			}),
+		).rejects.toThrow("diffColorAlt must contain three integer RGB channels");
+	});
+
 	it("rejects mismatched buffer size", async () => {
 		const a = loadPNG("pixelmatch/1a.png");
 		const short = new Uint8Array(4);
 		await expect(diff(short, a.data, a.width, a.height)).rejects.toThrow();
+	});
+});
+
+describe("diff() with interpretation", () => {
+	it("writes the same diff while returning interpretation", async () => {
+		const a = loadPNG("pixelmatch/1a.png");
+		const b = loadPNG("pixelmatch/1b.png");
+		const standalone = new Uint8Array(a.data.length);
+		const combined = new Uint8Array(a.data.length);
+		const options = {
+			includeAA: true,
+			diffColorAlt: [0, 128, 255] as [number, number, number],
+		};
+		const diffCount = await diff(
+			a.data,
+			b.data,
+			a.width,
+			a.height,
+			standalone,
+			options,
+		);
+
+		const result = await diff(a.data, b.data, a.width, a.height, combined, {
+			...options,
+			interpret: true,
+		});
+
+		expect(result.match).toBe(false);
+		if (!result.match) {
+			expect(result.diffCount).toBe(diffCount);
+			expect(result.interpretation.diffCount).toBe(diffCount);
+		}
+		expect(combined).toEqual(standalone);
+	});
+
+	it("preserves output for identical buffers", async () => {
+		const a = loadPNG("pixelmatch/1a.png");
+		const out = new Uint8Array(a.data.length).fill(17);
+
+		const result = await diff(a.data, a.data, a.width, a.height, out, {
+			interpret: true,
+		});
+
+		expect(result.match).toBe(true);
+		expect(result.interpretation.totalRegions).toBe(0);
+		expect(out.every((value) => value === 17)).toBe(true);
 	});
 });
 

--- a/packages/core-wasm/src/index.ts
+++ b/packages/core-wasm/src/index.ts
@@ -3,6 +3,32 @@ import init, {
 	interpretRgba as wasmInterpretRgba,
 } from "../wasm/blazediff.js";
 
+// Generated bindings are updated in version bump PRs, so keep the source-side
+// ABI explicit while this wrapper targets the next generated artifact.
+type WasmDiffRgba = (
+	rgbaA: Uint8Array,
+	rgbaB: Uint8Array,
+	width: number,
+	height: number,
+	threshold: number,
+	includeAA: boolean,
+	diffMask: boolean,
+	diffColorAlt: Uint8Array | undefined,
+	outDiff: Uint8Array | undefined,
+) => number;
+
+type WasmInterpretRgba = (
+	rgbaA: Uint8Array,
+	rgbaB: Uint8Array,
+	width: number,
+	height: number,
+	threshold: number,
+	includeAA: boolean,
+	diffMask: boolean,
+	diffColorAlt: Uint8Array | undefined,
+	outDiff: Uint8Array | undefined,
+) => unknown;
+
 export interface DiffOptions {
 	/** Color difference threshold (0-1). Lower = stricter. Default: 0.1 */
 	threshold?: number;
@@ -10,6 +36,13 @@ export interface DiffOptions {
 	includeAA?: boolean;
 	/** Render output with transparent background instead of grayscale base. Default: false */
 	diffMask?: boolean;
+	/** Alternative RGB color for darkening differences. Default: diff color */
+	diffColorAlt?: [number, number, number];
+}
+
+export interface InterpretedDiffOptions extends DiffOptions {
+	/** Return structured interpretation from the same diff pass. */
+	interpret: true;
 }
 
 export interface InterpretOptions {
@@ -84,6 +117,16 @@ export interface InterpretResult {
 	height: number;
 }
 
+export type DiffResult =
+	| { match: true; interpretation: InterpretResult }
+	| {
+			match: false;
+			reason: "pixel-diff";
+			diffCount: number;
+			diffPercentage: number;
+			interpretation: InterpretResult;
+	  };
+
 export type WasmInput =
 	| RequestInfo
 	| URL
@@ -92,6 +135,36 @@ export type WasmInput =
 	| WebAssembly.Module;
 
 let initPromise: Promise<unknown> | undefined;
+
+function toWasmRgb(
+	color: [number, number, number] | undefined,
+): Uint8Array | undefined {
+	if (!color) return undefined;
+	if (
+		color.length !== 3 ||
+		color.some(
+			(channel) => !Number.isInteger(channel) || channel < 0 || channel > 255,
+		)
+	) {
+		throw new RangeError(
+			"diffColorAlt must contain three integer RGB channels",
+		);
+	}
+	return Uint8Array.from(color);
+}
+
+function toDiffResult(interpretation: InterpretResult): DiffResult {
+	if (interpretation.diffCount === 0) {
+		return { match: true, interpretation };
+	}
+	return {
+		match: false,
+		reason: "pixel-diff",
+		diffCount: interpretation.diffCount,
+		diffPercentage: interpretation.diffPercentage,
+		interpretation,
+	};
+}
 
 /**
  * Initialize the wasm module. Safe to call multiple times - subsequent calls
@@ -116,18 +189,57 @@ export function initBlazediff(input?: WasmInput): Promise<void> {
  * the `ImageDecoder` API) and pass the resulting `Uint8Array` here.
  *
  * If `output` is provided it must be `width * height * 4` bytes long and the
- * diff visualization is written into it in place.
+ * diff visualization is written into it in place. Set `interpret: true` to
+ * return structured interpretation from the same diff pass.
  */
+export function diff(
+	a: Uint8Array,
+	b: Uint8Array,
+	width: number,
+	height: number,
+	output: Uint8Array | undefined,
+	options: InterpretedDiffOptions,
+): Promise<DiffResult>;
+export function diff(
+	a: Uint8Array,
+	b: Uint8Array,
+	width: number,
+	height: number,
+	output?: Uint8Array,
+	options?: DiffOptions & { interpret?: false },
+): Promise<number>;
+export function diff(
+	a: Uint8Array,
+	b: Uint8Array,
+	width: number,
+	height: number,
+	output?: Uint8Array,
+	options?: DiffOptions & { interpret?: boolean },
+): Promise<number | DiffResult>;
 export async function diff(
 	a: Uint8Array,
 	b: Uint8Array,
 	width: number,
 	height: number,
 	output?: Uint8Array,
-	options: DiffOptions = {},
-): Promise<number> {
+	options: DiffOptions & { interpret?: boolean } = {},
+): Promise<number | DiffResult> {
 	await initBlazediff();
-	return wasmDiffRgba(
+	if (!options.interpret) {
+		return (wasmDiffRgba as unknown as WasmDiffRgba)(
+			a,
+			b,
+			width,
+			height,
+			options.threshold ?? 0.1,
+			options.includeAA ?? false,
+			options.diffMask ?? false,
+			toWasmRgb(options.diffColorAlt),
+			output,
+		);
+	}
+
+	const interpretation = (wasmInterpretRgba as unknown as WasmInterpretRgba)(
 		a,
 		b,
 		width,
@@ -135,8 +247,11 @@ export async function diff(
 		options.threshold ?? 0.1,
 		options.includeAA ?? false,
 		options.diffMask ?? false,
+		toWasmRgb(options.diffColorAlt),
 		output,
-	);
+	) as InterpretResult;
+
+	return toDiffResult(interpretation);
 }
 
 /**
@@ -156,13 +271,9 @@ export async function interpret(
 	height: number,
 	options: InterpretOptions = {},
 ): Promise<InterpretResult> {
-	await initBlazediff();
-	return wasmInterpretRgba(
-		a,
-		b,
-		width,
-		height,
-		options.threshold ?? 0.1,
-		options.includeAA ?? false,
-	) as InterpretResult;
+	const result = await diff(a, b, width, height, undefined, {
+		...options,
+		interpret: true,
+	});
+	return result.interpretation;
 }


### PR DESCRIPTION
**What:** Add diffColorAlt to core-native and core-wasm, and combine WASM diff output with interpretation in one call. Refs #83 and #84.
**Why:** Keep native and WASM behavior aligned while avoiding duplicate WASM diff work.
**How:** Share one Rust diff pass across output and interpretation, wire both source bindings and wrappers, and cover the APIs with tests.