### PR TITLE
feat: accept native buffer inputs

### DIFF
--- a/.changeset/quiet-buffers-compare.md
+++ b/.changeset/quiet-buffers-compare.md
@@ -1,0 +1,5 @@
+---
+"@blazediff/core-native": minor
+---
+
+Accept encoded `Buffer` and `Uint8Array` inputs in `compare` and `interpret` without copying their JavaScript backing memory into Rust.

--- a/apps/image-benchmark/package.json
+++ b/apps/image-benchmark/package.json
@@ -13,6 +13,7 @@
 		"clean": "rm -rf dist",
 		"core": "node dist/pixel-by-pixel/blazediff-core-benchmark.js",
 		"core-native": "node dist/pixel-by-pixel/blazediff-core-native-benchmark.js",
+		"core-native-buffer": "node dist/pixel-by-pixel/blazediff-core-native-benchmark.js --variant=buffer",
 		"core-wasm": "node dist/pixel-by-pixel/blazediff-core-wasm-benchmark.js",
 		"odiff": "node dist/pixel-by-pixel/blazediff-odiff-benchmark.js",
 		"pixelmatch": "node dist/pixel-by-pixel/external-pixelmatch-benchmark.js",

--- a/apps/image-benchmark/src/pixel-by-pixel/blazediff-core-native-benchmark.ts
+++ b/apps/image-benchmark/src/pixel-by-pixel/blazediff-core-native-benchmark.ts
@@ -1,17 +1,34 @@
 #!/usr/bin/env node
 
+import { readFile } from "node:fs/promises";
 import { compare, hasNativeBinding } from "@blazediff/core-native";
 import { Bench, hrtimeNow } from "tinybench";
 import { getBenchmarkImagePairs, parseBenchmarkArgs } from "../utils";
 
 async function main() {
-	const { iterations, format, output, fixtures } = parseBenchmarkArgs();
+	const { iterations, format, output, fixtures, variant } =
+		parseBenchmarkArgs();
 
 	console.log(`[blazediff] Starting benchmark with ${iterations} iterations`);
 	console.log(`[blazediff] Native binding available: ${hasNativeBinding()}`);
 
 	const pairs = getBenchmarkImagePairs(fixtures);
 	console.log(`[blazediff] Found ${pairs.length} image pairs`);
+
+	const useBuffers = variant === "buffer";
+	const buffersByPath = useBuffers
+		? new Map(
+				await Promise.all(
+					[...new Set(pairs.flatMap((pair) => [pair.a, pair.b]))].map(
+						async (imagePath) =>
+							[imagePath, await readFile(imagePath)] as const,
+					),
+				),
+			)
+		: undefined;
+	console.log(
+		`[blazediff] Input mode: ${useBuffers ? `buffers (${buffersByPath?.size} shared allocations)` : "paths"}`,
+	);
 
 	const bench = new Bench({
 		iterations,
@@ -20,11 +37,15 @@ async function main() {
 		now: hrtimeNow,
 	});
 
-	for (let i = 0; i < pairs.length; i++) {
-		const pair = pairs[i];
+	for (const pair of pairs) {
+		const base = buffersByPath?.get(pair.a) ?? pair.a;
+		const comparison = buffersByPath?.get(pair.b) ?? pair.b;
+		const label = useBuffers ? "blazediff buffers" : "blazediff";
 
-		bench.add(`blazediff - ${pairs[i].name}`, async () => {
-			await compare(pair.a, pair.b, "/tmp/test.png", { antialiasing: true });
+		bench.add(`${label} - ${pair.name}`, async () => {
+			await compare(base, comparison, "/tmp/test.png", {
+				antialiasing: true,
+			});
 		});
 	}
 

--- a/apps/website/app/agent/page.tsx
+++ b/apps/website/app/agent/page.tsx
@@ -1,9 +1,7 @@
 import AgentTerminalDemo from "../../components/landing/agent-terminal-demo";
 import CtaLink from "../../components/landing/cta-link";
 import Hero from "../../components/landing/hero";
-import HeroHeading, {
-	HeroGradient,
-} from "../../components/landing/hero-heading";
+import HeroHeading, { HeroAccent } from "../../components/landing/hero-heading";
 import HeroSubhead from "../../components/landing/hero-subhead";
 import InstallSnippet from "../../components/landing/install-snippet";
 import NumberedCard from "../../components/landing/numbered-card";
@@ -85,12 +83,12 @@ export default function AgentPage() {
 							<br />
 							TESTING FOR YOUR
 							<br />
-							<HeroGradient>CODING AGENT</HeroGradient>
+							<HeroAccent>CODING AGENT</HeroAccent>
 						</HeroHeading>
 						<HeroSubhead>
-							YOUR CODING AGENT RUNS THE TESTS AND JUDGES AMBIGUOUS DIFFS FROM
-							COMPACT REGION TILES. NO EMBEDDED LLM. NO API KEY. NO PER-SNAPSHOT
-							BILL. OPEN SOURCE FROM CLI TO CI.
+							Your coding agent runs the tests and judges ambiguous diffs from
+							compact region tiles. No embedded LLM. No API key. No per-snapshot
+							bill. Open source from CLI to CI.
 						</HeroSubhead>
 						<InstallSnippet
 							commands={[
@@ -109,7 +107,7 @@ export default function AgentPage() {
 
 			<Section
 				title="WHY THIS DESIGN"
-				intro="FOUR DECISIONS THAT KEEP THE LOOP CHEAP, AUDITABLE, AND OUTSIDE A VENDOR'S CLOUD."
+				intro="Four decisions that keep the loop cheap, auditable, and outside a vendor's cloud."
 			>
 				<div className="flex flex-col gap-20 md:gap-24">
 					{PRINCIPLES.map((p, i) => (
@@ -120,7 +118,7 @@ export default function AgentPage() {
 
 			<Section
 				title="HOW IT WORKS"
-				intro="TWO TOUCHPOINTS. ONE COMMAND TO AUTHOR FROM YOUR CODING AGENT, ONE STEP IN CI TO ENFORCE."
+				intro="Two touchpoints. One command to author from your coding agent, one step in CI to enforce."
 			>
 				<div className="grid grid-cols-1 md:grid-cols-2 gap-8">
 					{PROTOCOL.map((step) => (
@@ -131,7 +129,7 @@ export default function AgentPage() {
 
 			<Section
 				title="REPORT OUTPUT"
-				intro="EVERY CHECK WRITES A 5-COLUMN MARKDOWN REPORT WITH BASELINE, ACTUAL, AND DIFF THUMBNAILS PER ROUTE. THE SAMPLE BELOW IS FROM A REAL RUN ON THIS WEBSITE."
+				intro="Every check writes a 5-column Markdown report with baseline, actual, and diff thumbnails per route. The sample below is from a real run on this website."
 			>
 				<TerminalFrame title=".blazediff/summary.md">
 					<div className="p-6 bg-canvas flex flex-col gap-6">

--- a/apps/website/app/apis/core-native/page.mdx
+++ b/apps/website/app/apis/core-native/page.mdx
@@ -25,7 +25,7 @@ Pre-built binaries are included for all major platforms - no compilation require
 
 ## Features
 
-- **PNG, JPEG & QOI support** - auto-detected by file extension
+- **PNG, JPEG & QOI support** - auto-detected by file extension or encoded bytes
 - **3-4x faster** than odiff, **3x smaller** binaries (~700KB-900KB vs ~2-3MB)
 - **SIMD-accelerated** - NEON on ARM, SSE4.1 on x86
 - **Block-based optimization** - skips unchanged regions
@@ -39,18 +39,18 @@ Pre-built binaries are included for all major platforms - no compilation require
 
 ## API Reference
 
-### `compare(basePath, comparePath, diffOutput, options?)`
+### `compare(base, comparison, diffOutput, options?)`
 
-Compares two images (PNG, JPEG, or QOI) and generates a diff image. Format is auto-detected from file extension.
+Compares two images from file paths or encoded `Buffer`/`Uint8Array` inputs and optionally generates a diff image. Both inputs must use the same input type. Format is auto-detected from the file extension or encoded bytes.
 
 #### Parameters
 
-| Parameter     | Type              | Description                           |
-| ------------- | ----------------- | ------------------------------------- |
-| `basePath`    | `string`          | Path to the base/expected image       |
-| `comparePath` | `string`          | Path to the comparison/actual image   |
-| `diffOutput`  | `string`          | Path where the diff image will be saved |
-| `options`     | `BlazeDiffOptions` | Comparison options (optional)         |
+| Parameter     | Type                      | Description                                  |
+| ------------- | ------------------------- | -------------------------------------------- |
+| `base`        | `string \| Uint8Array`     | Base/expected image path or encoded bytes    |
+| `comparison`  | `string \| Uint8Array`     | Comparison/actual image path or encoded bytes |
+| `diffOutput`  | `string`                  | Path where the diff image will be saved      |
+| `options`     | `BlazeDiffOptions`        | Comparison options (optional)                |
 
 ##### Options
 
@@ -73,6 +73,12 @@ type BlazeDiffResult =
 ```
 
 When `interpret: true`, the requested diff output is written and the result includes an `interpretation` field from the same diff pass.
+
+<Callout type="info">
+  Encoded inputs are passed by reference across the N-API boundary. Rust borrows
+  the existing JavaScript backing memory for the synchronous call. Image decoding
+  still allocates native RGBA pixel buffers.
+</Callout>
 
 <Callout type="info">
   **Threshold Guidelines:**
@@ -101,6 +107,21 @@ if (result.match) {
 } else if (result.reason === 'layout-diff') {
   console.log('Images have different dimensions');
 }
+```
+
+### Encoded Buffer Input
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { compare } from "@blazediff/core-native";
+
+const [expected, actual] = await Promise.all([
+  readFile("expected.png"),
+  readFile("actual.png"),
+]);
+
+// Reuse these same Buffer objects across comparisons without a JS-to-Rust copy.
+const result = await compare(expected, actual, "diff.png");
 ```
 
 ### CLI Usage
@@ -176,7 +197,7 @@ Input images can be mixed formats (e.g., compare PNG to JPEG). Output format is 
 
 ### Interpret
 
-Structured diff analysis. Takes two images, returns classified change regions with human-readable summaries.
+Structured diff analysis for matching path or encoded byte inputs. Returns classified change regions with human-readable summaries.
 
 **Pipeline:** change mask → morph close → connected components → per-region evidence extraction → classify → describe
 

--- a/apps/website/app/docs/pixel-comparison/rust-napi/page.mdx
+++ b/apps/website/app/docs/pixel-comparison/rust-napi/page.mdx
@@ -4,10 +4,10 @@ import { Tabs } from "nextra/components";
 import DiffImageComparison from "../../../../components/diff-image-comparison";
 
 The fastest path: native Rust compiled to a Node addon via N-API, ~3-4× faster
-than odiff. `@blazediff/core-native` works on **file paths** - it decodes PNG,
-JPEG, and QOI itself (in parallel) and can write the diff image straight to disk.
-Reach for it in Node test runners and CI where you have files and want maximum
-throughput.
+than odiff. `@blazediff/core-native` accepts file paths or encoded `Buffer` and
+`Uint8Array` inputs. It decodes PNG, JPEG, and QOI itself in parallel and can
+write the diff image straight to disk. Reach for it in Node test runners and CI
+when you want maximum throughput.
 
 ## Installation
 
@@ -17,7 +17,7 @@ npm install @blazediff/core-native
 
 ## Examples
 
-<Tabs items={['Basic Comparison', 'Custom Threshold', 'Write Diff Image']}>
+<Tabs items={['Basic Comparison', 'Buffer Comparison', 'Custom Threshold', 'Write Diff Image']}>
   <Tabs.Tab>
 
     <DiffImageComparison
@@ -37,6 +37,23 @@ if (result.match) {
 } else if (result.reason === "layout-diff") {
   console.log("dimensions differ");
 }
+```
+
+  </Tabs.Tab>
+
+  <Tabs.Tab>
+
+```ts
+import { readFile } from "node:fs/promises";
+import { compare } from "@blazediff/core-native";
+
+const [expected, actual] = await Promise.all([
+  readFile("3a.png"),
+  readFile("3b.png"),
+]);
+
+// The native binding borrows these Buffer allocations without copying them.
+const result = await compare(expected, actual);
 ```
 
   </Tabs.Tab>
@@ -77,6 +94,10 @@ const result = await compare("3a.png", "3b.png", "diff.png");
 
   </Tabs.Tab>
 </Tabs>
+
+Encoded inputs are borrowed directly for each synchronous native call, so the
+JavaScript bytes are not copied into Rust. PNG, JPEG, or QOI decoding still
+allocates native RGBA pixel buffers.
 
 Want a verdict on *what* changed, not just how many pixels? Pass `interpret: true`
 or use the dedicated [Image Difference Analysis →](/docs/difference-analysis)

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import BenchmarkChart from "../components/landing/benchmark-chart";
 import CtaLink from "../components/landing/cta-link";
 import Hero from "../components/landing/hero";
-import HeroHeading, { HeroGradient } from "../components/landing/hero-heading";
+import HeroHeading, { HeroAccent } from "../components/landing/hero-heading";
 import HeroInterpret from "../components/landing/hero-interpret";
 import HeroSubhead from "../components/landing/hero-subhead";
 import InstallSnippet from "../components/landing/install-snippet";
@@ -233,14 +233,14 @@ export default function Home() {
 							<br />
 							PIXEL DIFF.
 							<br />
-							<HeroGradient>AGENT-IN-THE-LOOP</HeroGradient>
+							<HeroAccent>AGENT-IN-THE-LOOP</HeroAccent>
 							<br />
-							<HeroGradient>VERDICTS.</HeroGradient>
+							<HeroAccent>VERDICTS.</HeroAccent>
 						</HeroHeading>
 						<HeroSubhead>
-							RUST, WASM, AND JS DIFF CORES. SSIM AND GMSD METRICS. JEST,
-							VITEST, AND BUN MATCHERS. AN AGENT THAT HANDS AMBIGUOUS DIFFS TO
-							CLAUDE CODE, CURSOR, OR CODEX. NO SAAS. NO API KEY. MIT.
+							Rust, WASM, and JS diff cores. SSIM and GMSD metrics. Jest,
+							Vitest, and Bun matchers. An agent that hands ambiguous diffs to
+							Claude Code, Cursor, or Codex. No SaaS. No API key. MIT.
 						</HeroSubhead>
 						<InstallSnippet commands="npm install @blazediff/core" />
 					</>
@@ -266,11 +266,11 @@ export default function Home() {
 
 			<Section
 				title="BENCHMARKS"
-				intro="REPRODUCIBLE FROM THE REPO. SAME FIXTURES, SAME HARDWARE (M1 MAX), HYPERFINE-MEASURED."
+				intro="Reproducible from the repo. Same fixtures, same hardware (M1 Max), hyperfine-measured."
 			>
 				<BenchmarkChart
 					groups={BENCHMARK_GROUPS}
-					footnote="FULL TABLE IN BENCHMARKS.MD AT THE REPO ROOT. EVERY ROW HAS A FIXTURE AND A METHODOLOGY NOTE."
+					footnote="Full table in BENCHMARKS.md at the repo root. Every row has a fixture and a methodology note."
 				/>
 			</Section>
 
@@ -296,7 +296,7 @@ export default function Home() {
 
 			<Section
 				title="THE STACK"
-				intro="ONE MONOREPO. FOUR LAYERS. INSTALL ONE PACKAGE OR THE WHOLE STACK."
+				intro="One monorepo. Four layers. Install one package or the whole stack."
 			>
 				<div className="flex flex-col gap-12">
 					{TIER_ORDER.map((tier) => {

--- a/apps/website/components/landing/benchmark-chart.tsx
+++ b/apps/website/components/landing/benchmark-chart.tsx
@@ -75,7 +75,9 @@ export default function BenchmarkChart({
 				);
 			})}
 			{footnote && (
-				<p className="font-mono text-[12px] text-muted uppercase">{footnote}</p>
+				<p className="font-sans text-[13px] text-muted leading-relaxed">
+					{footnote}
+				</p>
 			)}
 		</div>
 	);

--- a/apps/website/components/landing/hero-heading.tsx
+++ b/apps/website/components/landing/hero-heading.tsx
@@ -8,10 +8,6 @@ export default function HeroHeading({ children }: { children: ReactNode }) {
 	);
 }
 
-export function HeroGradient({ children }: { children: ReactNode }) {
-	return (
-		<span className="bg-clip-text text-transparent bg-gradient-to-r from-accent to-magenta">
-			{children}
-		</span>
-	);
+export function HeroAccent({ children }: { children: ReactNode }) {
+	return <span className="text-accent">{children}</span>;
 }

--- a/apps/website/components/landing/hero-subhead.tsx
+++ b/apps/website/components/landing/hero-subhead.tsx
@@ -6,7 +6,7 @@ interface HeroSubheadProps {
 
 export default function HeroSubhead({ children }: HeroSubheadProps) {
 	return (
-		<p className="font-mono text-[14px] text-muted max-w-lg uppercase">
+		<p className="font-sans text-[15px] md:text-[16px] text-muted max-w-lg leading-relaxed">
 			{children}
 		</p>
 	);

--- a/apps/website/components/landing/nav.tsx
+++ b/apps/website/components/landing/nav.tsx
@@ -34,8 +34,8 @@ export default function LandingNav({
 	ctaHref,
 }: LandingNavProps) {
 	return (
-		<nav className="bg-surface/80 backdrop-blur-md font-mono text-[14px] uppercase tracking-wider sticky top-0 border-b border-line z-40">
-			<div className="flex justify-between items-center gap-3 w-full px-4 md:px-10 py-2 max-w-screen-2xl mx-auto h-16">
+		<nav className="sticky max-w-screen-2xl w-full mx-auto top-0 z-40 px-10 pt-3 md:pt-4">
+			<div className="w-full bg-surface/80 backdrop-blur-md border border-line font-mono text-[14px] uppercase tracking-wider flex justify-between items-center gap-3 px-4 md:px-6 py-2 h-14">
 				<Link
 					href="/"
 					className="flex items-center gap-2 md:gap-4 shrink min-w-0"

--- a/apps/website/components/landing/section.tsx
+++ b/apps/website/components/landing/section.tsx
@@ -27,7 +27,7 @@ export default function Section({
 				</h2>
 			)}
 			{intro && (
-				<p className="font-mono text-[14px] text-muted mb-12 max-w-2xl uppercase">
+				<p className="font-sans text-[15px] text-muted mb-12 max-w-2xl leading-relaxed">
 					{intro}
 				</p>
 			)}

--- a/apps/website/components/landing/terminal-frame.tsx
+++ b/apps/website/components/landing/terminal-frame.tsx
@@ -15,13 +15,8 @@ export default function TerminalFrame({
 		<div
 			className={`bg-terminal border border-line p-2 flex flex-col gap-2 relative ${className}`}
 		>
-			<div className="flex items-center justify-between border-b border-line pb-2 px-2">
+			<div className="flex items-center border-b border-line pb-2 px-2">
 				<span className="font-mono text-[14px] text-accent">{title}</span>
-				<div className="flex gap-2 shrink-0">
-					<div className="w-2 h-2 bg-muted" />
-					<div className="w-2 h-2 bg-muted" />
-					<div className="w-2 h-2 bg-magenta" />
-				</div>
 			</div>
 			{children}
 		</div>

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -8,7 +8,7 @@
 ## Performance
 
 - **Native (Rust)**: 3-4x faster than odiff, 8x faster than pixelmatch on 4K images
-ge, up to ~5x on 4K (browser, edge, any wasm host)
+- **WASM**: ~58% faster than pixelmatch, up to ~5x on 4K (browser, edge, any wasm host)
 - **Image Pixel-by-Pixel (JS)**: ~50% faster than pixelmatch (up to 88% on identical images)
 - **SSIM**: ~25% faster than ssim.js, ~70% faster with Hitchhiker's SSIM
 - **Object Diff**: ~55% faster than microdiff (up to 96% on identical arrays)
@@ -1294,7 +1294,7 @@ Pre-built binaries are included for all major platforms - no compilation require
 
 ## Features
 
-- **PNG, JPEG & QOI support** - auto-detected by file extension
+- **PNG, JPEG & QOI support** - auto-detected by file extension or encoded bytes
 - **3-4x faster** than odiff, **3x smaller** binaries (~700KB-900KB vs ~2-3MB)
 - **SIMD-accelerated** - NEON on ARM, SSE4.1 on x86
 - **Block-based optimization** - skips unchanged regions
@@ -1308,18 +1308,18 @@ Pre-built binaries are included for all major platforms - no compilation require
 
 ## API Reference
 
-### `compare(basePath, comparePath, diffOutput, options?)`
+### `compare(base, comparison, diffOutput, options?)`
 
-Compares two images (PNG, JPEG, or QOI) and generates a diff image. Format is auto-detected from file extension.
+Compares two images from file paths or encoded `Buffer`/`Uint8Array` inputs and optionally generates a diff image. Both inputs must use the same input type. Format is auto-detected from the file extension or encoded bytes.
 
 #### Parameters
 
-| Parameter     | Type              | Description                           |
-| ------------- | ----------------- | ------------------------------------- |
-| `basePath`    | `string`          | Path to the base/expected image       |
-| `comparePath` | `string`          | Path to the comparison/actual image   |
-| `diffOutput`  | `string`          | Path where the diff image will be saved |
-| `options`     | `BlazeDiffOptions` | Comparison options (optional)         |
+| Parameter     | Type                      | Description                                  |
+| ------------- | ------------------------- | -------------------------------------------- |
+| `base`        | `string \| Uint8Array`     | Base/expected image path or encoded bytes    |
+| `comparison`  | `string \| Uint8Array`     | Comparison/actual image path or encoded bytes |
+| `diffOutput`  | `string`                  | Path where the diff image will be saved      |
+| `options`     | `BlazeDiffOptions`        | Comparison options (optional)                |
 
 ##### Options
 
@@ -1328,7 +1328,8 @@ Compares two images (PNG, JPEG, or QOI) and generates a diff image. Format is au
 | `threshold`        | `number`  | `0.1`   | Color difference threshold (0.0-1.0). Lower = more strict |
 | `antialiasing`     | `boolean` | `false` | Enable anti-aliasing detection                           |
 | `diffMask`         | `boolean` | `false` | Output only differences with transparent background      |
-| `interpret`        | `boolean` | `false` | Run structured interpretation (region detection + classification) |
+| `diffColorAlt`     | `[number, number, number]` | diff color | Alternative RGB color for darkening differences |
+| `interpret`        | `boolean` | `false` | Generate the diff image and structured interpretation in one pass |
 
 #### Return Types
 
@@ -1340,7 +1341,9 @@ type BlazeDiffResult =
   | { match: false; reason: "file-not-exists"; file: string };
 ```
 
-When `interpret: true`, the result includes an `interpretation` field with structured analysis.
+When `interpret: true`, the requested diff output is written and the result includes an `interpretation` field from the same diff pass.
+
+> **Info:** Encoded inputs are passed by reference across the N-API boundary. Rust borrows the existing JavaScript backing memory for the synchronous call. Image decoding still allocates native RGBA pixel buffers.
 
 > **Info:** **Threshold Guidelines:** - `0.0` - Exact match only - `0.05` - Strict comparison - `0.1` - Default balanced comparison - `0.2` - Lenient comparison
 
@@ -1363,6 +1366,21 @@ if (result.match) {
 } else if (result.reason === 'layout-diff') {
   console.log('Images have different dimensions');
 }
+```
+
+### Encoded Buffer Input
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { compare } from "@blazediff/core-native";
+
+const [expected, actual] = await Promise.all([
+  readFile("expected.png"),
+  readFile("actual.png"),
+]);
+
+// Reuse these same Buffer objects across comparisons without a JS-to-Rust copy.
+const result = await compare(expected, actual, "diff.png");
 ```
 
 ### CLI Usage
@@ -1407,6 +1425,7 @@ Options:
   -t, --threshold <THRESHOLD>  Color difference threshold (0.0-1.0) [default: 0.1]
   -a, --antialiasing           Enable anti-aliasing detection
       --diff-mask              Output only differences (transparent background)
+      --diff-color-alt <R,G,B> Alternative RGB color for darkening differences
   -c, --compression <LEVEL>    PNG compression level (0-9, 0=fastest, 9=smallest) [default: 0]
   -q, --quality <QUALITY>      JPEG quality (1-100) [default: 90]
       --interpret              Run structured interpretation after diff
@@ -1435,7 +1454,7 @@ Input images can be mixed formats (e.g., compare PNG to JPEG). Output format is 
 
 ### Interpret
 
-Structured diff analysis. Takes two images, returns classified change regions with human-readable summaries.
+Structured diff analysis for matching path or encoded byte inputs. Returns classified change regions with human-readable summaries.
 
 **Pipeline:** change mask → morph close → connected components → per-region evidence extraction → classify → describe
 
@@ -1599,7 +1618,7 @@ await initBlazediff(readFileSync(wasmPath));
 
 ### `diff(a, b, width, height, output?, options?)`
 
-Compares two RGBA pixel buffers and returns the number of differing pixels.
+Compares two RGBA pixel buffers and returns the number of differing pixels. Set `interpret: true` to return structured interpretation while producing the diff output in the same pass.
 
 #### Parameters
 
@@ -1610,7 +1629,7 @@ Compares two RGBA pixel buffers and returns the number of differing pixels.
 | `width`   | `number`              | Image width in pixels                                    |
 | `height`  | `number`              | Image height in pixels                                   |
 | `output`  | `Uint8Array \| undefined` | Optional diff visualization output (same length). Written in place |
-| `options` | `DiffOptions`         | Comparison options (optional)                            |
+| `options` | `DiffOptions \| InterpretedDiffOptions` | Comparison options (optional)                  |
 
 ##### Options
 
@@ -1619,8 +1638,35 @@ Compares two RGBA pixel buffers and returns the number of differing pixels.
 | `threshold`  | `number`  | `0.1`   | Color difference threshold (0.0-1.0). Lower = more strict |
 | `includeAA`  | `boolean` | `false` | Count anti-aliased pixels as differences                 |
 | `diffMask`   | `boolean` | `false` | Render diff with transparent background instead of grayscale base |
+| `diffColorAlt` | `[number, number, number]` | diff color | Alternative RGB color for darkening differences |
+| `interpret` | `boolean` | `false` | Return structured interpretation from the same diff pass |
 
 > **Info:** **Threshold Guidelines:** `0.0` exact match · `0.05` strict · `0.1` default · `0.2` lenient
+
+With `interpret: true`, `diff()` returns a `DiffResult` instead of a pixel count:
+
+```typescript
+const result = await diff(a, b, width, height, output, {
+  diffColorAlt: [0, 128, 255],
+  interpret: true,
+});
+```
+
+```typescript
+type DiffResult =
+  | { match: true; interpretation: InterpretResult }
+  | {
+      match: false;
+      reason: 'pixel-diff';
+      diffCount: number;
+      diffPercentage: number;
+      interpretation: InterpretResult;
+    };
+```
+
+### `interpret(a, b, width, height, options?)`
+
+Returns structured change regions without retaining a diff visualization. It is a convenience wrapper over `diff()` with `interpret: true`.
 
 ## Usage
 
@@ -3144,10 +3190,10 @@ Versus spng over the BlazeDiff corpus (34 PNGs, 342.7 MPx, up to 5600×3200), si
 | Operation | vs spng | How |
 | --- | --- | --- |
 | Decode | **~1.4×** | whole-buffer libdeflate inflate + SIMD defilter |
-| Encode, level 6 | **~5.8×** | libdeflate + NEON adaptive-filter kernels, at ~98% of spng's file size |
-| Encode, level 0 (stored) | **~1.8×** | uncompressed deflate blocks, copy- and allocation-light pipeline |
+| Encode, stored (level 0) | **~2.2×** | uncompressed deflate blocks, copy- and allocation-light pipeline |
+| Encode, compressed | **~3.8×** | libdeflate level 6 vs spng zlib 4, at ~94% of spng's file size |
 
-The wins come from doing less, not from threads: a whole-buffer inflate instead of spng's per-scanline gating, in-place sequential defiltering, autovectorizable row expansion, and hand-written NEON kernels for the encode SAD/filter hot path.
+The wins come from doing less, not from threads: a whole-buffer inflate instead of spng's per-scanline gating, in-place sequential defiltering, autovectorizable row expansion, and hand-written NEON kernels for the encode SAD/filter hot path. [See the full per-fixture benchmarks →](/benchmarks/png-codec)
 
 ## Library Usage
 
@@ -3392,10 +3438,10 @@ accepts a `URL`, `Response`, or raw bytes - see the
 # Pixel-by-pixel Comparison - Rust + N-API in Node
 
 The fastest path: native Rust compiled to a Node addon via N-API, ~3-4× faster
-than odiff. `@blazediff/core-native` works on **file paths** - it decodes PNG,
-JPEG, and QOI itself (in parallel) and can write the diff image straight to disk.
-Reach for it in Node test runners and CI where you have files and want maximum
-throughput.
+than odiff. `@blazediff/core-native` accepts file paths or encoded `Buffer` and
+`Uint8Array` inputs. It decodes PNG, JPEG, and QOI itself in parallel and can
+write the diff image straight to disk. Reach for it in Node test runners and CI
+when you want maximum throughput.
 
 ## Installation
 
@@ -3420,6 +3466,19 @@ if (result.match) {
 ```
 
 ```ts
+import { readFile } from "node:fs/promises";
+import { compare } from "@blazediff/core-native";
+
+const [expected, actual] = await Promise.all([
+  readFile("3a.png"),
+  readFile("3b.png"),
+]);
+
+// The native binding borrows these Buffer allocations without copying them.
+const result = await compare(expected, actual);
+```
+
+```ts
 import { compare } from "@blazediff/core-native";
 
 const result = await compare("3a.png", "3b.png", undefined, {
@@ -3435,6 +3494,10 @@ import { compare } from "@blazediff/core-native";
 // Format is inferred from the extension (PNG, JPEG, QOI).
 const result = await compare("3a.png", "3b.png", "diff.png");
 ```
+
+Encoded inputs are borrowed directly for each synchronous native call, so the
+JavaScript bytes are not copied into Rust. PNG, JPEG, or QOI decoding still
+allocates native RGBA pixel buffers.
 
 Want a verdict on *what* changed, not just how many pixels? Pass `interpret: true`
 or use the dedicated [Image Difference Analysis →](/docs/difference-analysis)

--- a/crates/blazediff/src/io.rs
+++ b/crates/blazediff/src/io.rs
@@ -39,14 +39,17 @@ impl Drop for CtxGuard {
 pub fn load_png<P: AsRef<Path>>(path: P) -> Result<Image, DiffError> {
     let file = File::open(path.as_ref())?;
     let file_data = unsafe { Mmap::map(&file)? };
+    decode_png(&file_data)
+}
 
+pub(crate) fn decode_png(file_data: &[u8]) -> Result<Image, DiffError> {
     // When enabled, blazediff_png decodes every format spng accepts,
     // byte-identically, and is substantially faster (whole-buffer libdeflate
     // inflate, SIMD defilter); spng stays as a defensive fallback should the
     // codec ever reject an input spng would have taken. Off by default while
     // the codec is experimental.
     if blazediff_png_enabled() {
-        if let Ok(img) = blazediff_png::decode(&file_data) {
+        if let Ok(img) = blazediff_png::decode(file_data) {
             return Ok(Image {
                 data: img.data,
                 width: img.width,
@@ -54,7 +57,7 @@ pub fn load_png<P: AsRef<Path>>(path: P) -> Result<Image, DiffError> {
             });
         }
     }
-    decode_spng(&file_data)
+    decode_spng(file_data)
 }
 
 /// Decode a PNG byte buffer through spng (FMT_RGBA8 + tRNS). The decode

--- a/crates/blazediff/src/jpeg_io.rs
+++ b/crates/blazediff/src/jpeg_io.rs
@@ -34,7 +34,10 @@ unsafe fn get_tj_error(handle: tjhandle) -> String {
 pub fn load_jpeg<P: AsRef<Path>>(path: P) -> Result<Image, DiffError> {
     let file = File::open(path.as_ref())?;
     let file_data = unsafe { Mmap::map(&file)? };
+    decode_jpeg(&file_data)
+}
 
+pub(crate) fn decode_jpeg(file_data: &[u8]) -> Result<Image, DiffError> {
     unsafe {
         // Initialize decompressor
         let handle = tj3Init(TJINIT_TJINIT_DECOMPRESS as i32);

--- a/crates/blazediff/src/napi.rs
+++ b/crates/blazediff/src/napi.rs
@@ -33,6 +33,19 @@ impl ImageFormat {
             _ => None,
         }
     }
+
+    fn from_bytes(data: &[u8]) -> Option<Self> {
+        if data.starts_with(b"\x89PNG\r\n\x1a\n") {
+            return Some(ImageFormat::Png);
+        }
+        if data.starts_with(&[0xff, 0xd8, 0xff]) {
+            return Some(ImageFormat::Jpeg);
+        }
+        if data.starts_with(b"qoif") {
+            return Some(ImageFormat::Qoi);
+        }
+        None
+    }
 }
 
 /// Load two images in parallel, auto-detecting format
@@ -69,6 +82,28 @@ fn load_images<P1: AsRef<Path> + Sync, P2: AsRef<Path> + Sync>(
 
     let mut iter = results.into_iter();
     Ok((iter.next().unwrap()?, iter.next().unwrap()?))
+}
+
+fn decode_image_buffer(data: &[u8]) -> std::result::Result<Image, DiffError> {
+    match ImageFormat::from_bytes(data) {
+        Some(ImageFormat::Png) => crate::io::decode_png(data),
+        Some(ImageFormat::Jpeg) => crate::jpeg_io::decode_jpeg(data),
+        Some(ImageFormat::Qoi) => crate::qoi_io::decode_qoi(data),
+        None => Err(DiffError::UnsupportedFormat(
+            "Unsupported image buffer format".to_string(),
+        )),
+    }
+}
+
+fn load_image_buffers(
+    image1: &[u8],
+    image2: &[u8],
+) -> std::result::Result<(Image, Image), DiffError> {
+    let (result1, result2) = rayon::join(
+        || decode_image_buffer(image1),
+        || decode_image_buffer(image2),
+    );
+    Ok((result1?, result2?))
 }
 
 /// Save an image, auto-detecting format from extension
@@ -135,13 +170,9 @@ fn optional_rgb(value: Option<Vec<u8>>, label: &str) -> Result<Option<[u8; 3]>> 
     }
 }
 
-/// Compare two images and optionally generate a diff image.
-///
-/// Returns a result object with match status and diff details.
-#[napi]
-pub fn compare(
-    base_path: String,
-    compare_path: String,
+fn compare_images(
+    img1: Image,
+    img2: Image,
     diff_output: Option<String>,
     options: Option<NapiDiffOptions>,
 ) -> Result<NapiDiffResult> {
@@ -162,14 +193,6 @@ pub fn compare(
     let compression = opts.compression.unwrap_or(0);
     let quality = opts.quality.unwrap_or(90);
     let run_interpret = opts.interpret.unwrap_or(false);
-
-    // Load images
-    let (img1, img2) = load_images(&base_path, &compare_path).map_err(|e| {
-        Error::new(
-            Status::GenericFailure,
-            format!("Failed to load images: {}", e),
-        )
-    })?;
 
     // Check for size mismatch - can't diff images of different sizes
     if img1.width != img2.width || img1.height != img2.height {
@@ -203,7 +226,7 @@ pub fn compare(
 
         let is_identical = result.diff_count == 0;
         if !is_identical {
-            if let (Some(ref output_path), Some(ref output)) = (&diff_output, &output_image) {
+            if let (Some(output_path), Some(output)) = (&diff_output, &output_image) {
                 save_image(output, output_path, compression, quality).map_err(|e| {
                     Error::new(
                         Status::GenericFailure,
@@ -250,7 +273,7 @@ pub fn compare(
 
     // Save diff image if requested and images differ
     if !result.identical {
-        if let (Some(ref output_path), Some(ref output)) = (&diff_output, &output_image) {
+        if let (Some(output_path), Some(output)) = (&diff_output, &output_image) {
             save_image(output, output_path, compression, quality).map_err(|e| {
                 Error::new(
                     Status::GenericFailure,
@@ -277,6 +300,40 @@ pub fn compare(
             interpretation: None,
         })
     }
+}
+
+/// Compare two images from paths and optionally generate a diff image.
+#[napi]
+pub fn compare(
+    base_path: String,
+    compare_path: String,
+    diff_output: Option<String>,
+    options: Option<NapiDiffOptions>,
+) -> Result<NapiDiffResult> {
+    let (img1, img2) = load_images(&base_path, &compare_path).map_err(|e| {
+        Error::new(
+            Status::GenericFailure,
+            format!("Failed to load images: {}", e),
+        )
+    })?;
+    compare_images(img1, img2, diff_output, options)
+}
+
+/// Compare two encoded image buffers and optionally generate a diff image.
+#[napi]
+pub fn compare_buffers(
+    base: &[u8],
+    comparison: &[u8],
+    diff_output: Option<String>,
+    options: Option<NapiDiffOptions>,
+) -> Result<NapiDiffResult> {
+    let (img1, img2) = load_image_buffers(base, comparison).map_err(|e| {
+        Error::new(
+            Status::GenericFailure,
+            format!("Failed to load images: {}", e),
+        )
+    })?;
+    compare_images(img1, img2, diff_output, options)
 }
 
 // ─── Interpret N-API bindings ────────────────────────────────────────────────

--- a/crates/blazediff/src/qoi_io.rs
+++ b/crates/blazediff/src/qoi_io.rs
@@ -9,9 +9,12 @@ use std::path::Path;
 pub fn load_qoi<P: AsRef<Path>>(path: P) -> Result<Image, DiffError> {
     let file = File::open(path.as_ref())?;
     let file_data = unsafe { Mmap::map(&file)? };
+    decode_qoi(&file_data)
+}
 
+pub(crate) fn decode_qoi(file_data: &[u8]) -> Result<Image, DiffError> {
     let (header, pixels) =
-        qoi::decode_to_vec(&file_data).map_err(|e| DiffError::QoiError(e.to_string()))?;
+        qoi::decode_to_vec(file_data).map_err(|e| DiffError::QoiError(e.to_string()))?;
 
     let width = header.width;
     let height = header.height;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"bench": "node scripts/bench/run.js",
 		"benchmark:core": "pnpm --filter @blazediff/image-benchmark core",
 		"benchmark:core-native": "pnpm --filter @blazediff/image-benchmark core-native",
+		"benchmark:core-native-buffer": "pnpm --filter @blazediff/image-benchmark core-native-buffer",
 		"benchmark:core-native-next": "BLAZEDIFF_PNG_ENABLED=1 pnpm --filter @blazediff/image-benchmark core-native",
 		"benchmark:core-wasm": "pnpm --filter @blazediff/image-benchmark core-wasm",
 		"benchmark:odiff": "pnpm --filter @blazediff/image-benchmark odiff",

--- a/packages/core-native-darwin-arm64/blazediff.node
+++ b/packages/core-native-darwin-arm64/blazediff.node
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:798b931416094d71d4d669ea14904059c9e2c8a30cb8986e68d43d4e87500a2c
-size 1301184
+oid sha256:e80f300288e54d03a639b63d0ccd2a89389e8fe9e5deb91cc627bfa9ac71519a
+size 1301296

--- a/packages/core-native-darwin-arm64/blazediff.node
+++ b/packages/core-native-darwin-arm64/blazediff.node
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e80f300288e54d03a639b63d0ccd2a89389e8fe9e5deb91cc627bfa9ac71519a
-size 1301296
+oid sha256:798b931416094d71d4d669ea14904059c9e2c8a30cb8986e68d43d4e87500a2c
+size 1301184

--- a/packages/core-native/README.md
+++ b/packages/core-native/README.md
@@ -11,7 +11,7 @@
 The fastest single-threaded image diff in the world. Native Rust implementation with SIMD optimization, **3-4x faster** and **3x smaller** than [odiff](https://github.com/dmtrKovalenko/odiff).
 
 **Features:**
-- **PNG, JPEG & QOI support** - auto-detected by file extension
+- **PNG, JPEG & QOI support** - auto-detected by file extension or encoded bytes
 - SIMD-accelerated (NEON on ARM, SSE4.1 on x86)
 - Block-based two-pass optimization
 - YIQ perceptual color difference
@@ -49,9 +49,9 @@ Pre-built binaries are included via platform-specific packages:
 
 ## API
 
-### compare(basePath, comparePath, diffOutput, options?)
+### compare(base, comparison, diffOutput, options?)
 
-Compare two images (PNG or JPEG) and generate a diff image. Format is auto-detected from file extension.
+Compare two images from file paths or encoded `Uint8Array`/`Buffer` inputs and optionally generate a diff image. Both inputs must use the same input type. Format is auto-detected from the file extension or encoded bytes.
 
 <table>
   <tr>
@@ -60,14 +60,14 @@ Compare two images (PNG or JPEG) and generate a diff image. Format is auto-detec
     <th width="500">Description</th>
   </tr>
   <tr>
-    <td><code>basePath</code></td>
-    <td>string</td>
-    <td>Path to the base/expected image</td>
+    <td><code>base</code></td>
+    <td>string | Uint8Array</td>
+    <td>Base/expected image path or encoded bytes</td>
   </tr>
   <tr>
-    <td><code>comparePath</code></td>
-    <td>string</td>
-    <td>Path to the comparison/actual image</td>
+    <td><code>comparison</code></td>
+    <td>string | Uint8Array</td>
+    <td>Comparison/actual image path or encoded bytes</td>
   </tr>
   <tr>
     <td><code>diffOutput</code></td>
@@ -82,6 +82,22 @@ Compare two images (PNG or JPEG) and generate a diff image. Format is auto-detec
 </table>
 
 <strong>Returns:</strong> `Promise<BlazeDiffResult>`
+
+#### Encoded Buffer Inputs
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { compare } from "@blazediff/core-native";
+
+const [expected, actual] = await Promise.all([
+  readFile("expected.png"),
+  readFile("actual.png"),
+]);
+
+const result = await compare(expected, actual, "diff.png");
+```
+
+The native binding borrows the existing `Buffer` or `Uint8Array` backing memory for the synchronous call. The encoded bytes are not copied into Rust, so the same JavaScript buffers can be reused across comparisons. Decoding still allocates native RGBA pixel buffers.
 
 <table>
   <tr>
@@ -122,9 +138,9 @@ Compare two images (PNG or JPEG) and generate a diff image. Format is auto-detec
   </tr>
 </table>
 
-### interpret(image1Path, image2Path, options?)
+### interpret(image1, image2, options?)
 
-Convenience wrapper that calls `compare` with `interpret: true` and returns the `InterpretResult` directly. No diff image output - purely analytical.
+Convenience wrapper that calls `compare` with `interpret: true` and returns the `InterpretResult` directly. Accepts matching path or encoded byte inputs. No diff image output - purely analytical.
 
 <table>
   <tr>
@@ -133,14 +149,14 @@ Convenience wrapper that calls `compare` with `interpret: true` and returns the 
     <th width="500">Description</th>
   </tr>
   <tr>
-    <td><code>image1Path</code></td>
-    <td>string</td>
-    <td>Path to the first image</td>
+    <td><code>image1</code></td>
+    <td>string | Uint8Array</td>
+    <td>First image path or encoded bytes</td>
   </tr>
   <tr>
-    <td><code>image2Path</code></td>
-    <td>string</td>
-    <td>Path to the second image</td>
+    <td><code>image2</code></td>
+    <td>string | Uint8Array</td>
+    <td>Second image path or encoded bytes</td>
   </tr>
   <tr>
     <td><code>options</code></td>

--- a/packages/core-native/src/index.test.ts
+++ b/packages/core-native/src/index.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { compare, getBinaryPath, hasNativeBinding } from "./index";
+import { compare, getBinaryPath, hasNativeBinding, interpret } from "./index";
 
 const execFileAsync = promisify(execFile);
 
@@ -36,6 +36,55 @@ describe("compare", () => {
 		const result = await compare(smallImage, largeImage);
 
 		expect(result).toEqual({ match: false, reason: "layout-diff" });
+	});
+
+	it.each([
+		["PNG", "pixelmatch/1a.png"],
+		["JPEG", "4k-jpeg/1a.jpg"],
+		["QOI", "4k-qoi/1a.qoi"],
+	])("should compare encoded %s Buffer inputs", async (_, relativePath) => {
+		const image = await readFile(join(FIXTURES_PATH, relativePath));
+		await expect(compare(image, image)).resolves.toEqual({ match: true });
+	});
+
+	it("should compare Uint8Array views with non-zero offsets", async () => {
+		const path1 = join(FIXTURES_PATH, "pixelmatch/1a.png");
+		const path2 = join(FIXTURES_PATH, "pixelmatch/1b.png");
+		const [image1, image2, pathResult] = await Promise.all([
+			readFile(path1),
+			readFile(path2),
+			compare(path1, path2),
+		]);
+		const storage1 = new Uint8Array(image1.length + 8);
+		const storage2 = new Uint8Array(image2.length + 8);
+		storage1.set(image1, 4);
+		storage2.set(image2, 4);
+
+		const bufferResult = await compare(
+			storage1.subarray(4, image1.length + 4),
+			storage2.subarray(4, image2.length + 4),
+		);
+		expect(bufferResult).toEqual(pathResult);
+	});
+
+	it("should interpret encoded Buffer inputs", async () => {
+		const [image1, image2] = await Promise.all([
+			readFile(join(FIXTURES_PATH, "pixelmatch/1a.png")),
+			readFile(join(FIXTURES_PATH, "pixelmatch/1b.png")),
+		]);
+		const result = await interpret(image1, image2);
+
+		expect(result.diffCount).toBeGreaterThan(0);
+		expect(result.totalRegions).toBeGreaterThan(0);
+	});
+
+	it("should reject mixed path and byte array inputs", async () => {
+		const imagePath = join(FIXTURES_PATH, "pixelmatch/1a.png");
+		const image = await readFile(imagePath);
+
+		await expect(compare(imagePath, image)).rejects.toThrow(
+			"Image inputs must both be file paths or both be encoded byte arrays",
+		);
 	});
 
 	it("should return file-not-exists when base image is missing", async () => {

--- a/packages/core-native/src/index.ts
+++ b/packages/core-native/src/index.ts
@@ -25,6 +25,9 @@ export interface BlazeDiffOptions {
 	interpret?: boolean;
 }
 
+/** File path or encoded PNG, JPEG, or QOI bytes. */
+export type BlazeDiffInput = string | Uint8Array;
+
 export type BlazeDiffResult =
 	| { match: true; interpretation?: InterpretResult }
 	| { match: false; reason: "layout-diff" }
@@ -142,6 +145,12 @@ interface NativeBinding {
 	compare(
 		basePath: string,
 		comparePath: string,
+		diffOutput: string | null,
+		options: NapiDiffOptions | null,
+	): NapiDiffResult;
+	compareBuffers(
+		base: Uint8Array,
+		comparison: Uint8Array,
 		diffOutput: string | null,
 		options: NapiDiffOptions | null,
 	): NapiDiffResult;
@@ -501,19 +510,22 @@ async function execFileInterpretCompare(
 }
 
 /**
- * Compare two images (PNG or JPEG) and optionally generate a diff image.
+ * Compare two encoded images (PNG, JPEG, or QOI) and optionally generate a diff image.
+ *
+ * Inputs must both be file paths or both be encoded byte arrays. Node.js Buffer
+ * values are Uint8Array instances and can be passed directly.
  *
  * Uses native N-API bindings when available for ~10-100x better performance
- * on small images (no process spawn overhead). Falls back to execFile if
- * native bindings are unavailable.
+ * on small images (no process spawn overhead). Path inputs fall back to
+ * execFile if native bindings are unavailable.
  *
  * @example
  * ```ts
- * // With diff output
+ * // With file paths and diff output
  * const result = await compare('expected.png', 'actual.png', 'diff.png');
  *
- * // Without diff output (faster, just returns comparison result)
- * const result = await compare('expected.png', 'actual.png');
+ * // With encoded image buffers
+ * const result = await compare(expectedPngBuffer, actualPngBuffer);
  *
  * if (result.match) {
  *   console.log('Images identical');
@@ -523,36 +535,57 @@ async function execFileInterpretCompare(
  * ```
  */
 export async function compare(
-	basePath: string,
-	comparePath: string,
+	base: BlazeDiffInput,
+	comparison: BlazeDiffInput,
 	diffOutput?: string,
 	options?: BlazeDiffOptions,
 ): Promise<BlazeDiffResult> {
-	// Try native binding first for better performance
+	const baseIsPath = typeof base === "string";
+	const comparisonIsPath = typeof comparison === "string";
+	if (baseIsPath !== comparisonIsPath) {
+		throw new TypeError(
+			"Image inputs must both be file paths or both be encoded byte arrays",
+		);
+	}
+
 	const binding = tryLoadNativeBinding();
 	if (binding) {
 		try {
-			const result = binding.compare(
-				basePath,
-				comparePath,
-				diffOutput ?? null,
-				convertToNapiOptions(options),
-			);
+			const result =
+				baseIsPath && comparisonIsPath
+					? binding.compare(
+							base,
+							comparison,
+							diffOutput ?? null,
+							convertToNapiOptions(options),
+						)
+					: binding.compareBuffers(
+							base as Uint8Array,
+							comparison as Uint8Array,
+							diffOutput ?? null,
+							convertToNapiOptions(options),
+						);
 			return convertNapiResult(result);
 		} catch (err) {
-			// Check if it's a file-not-exists error
-			const message = err instanceof Error ? err.message : String(err);
-			const missingFile = detectMissingFile(message, basePath, comparePath);
-			if (missingFile) {
-				return { match: false, reason: "file-not-exists", file: missingFile };
+			if (baseIsPath && comparisonIsPath) {
+				const message = err instanceof Error ? err.message : String(err);
+				const missingFile = detectMissingFile(message, base, comparison);
+				if (missingFile) {
+					return {
+						match: false,
+						reason: "file-not-exists",
+						file: missingFile,
+					};
+				}
 			}
-			// Re-throw other errors
 			throw err;
 		}
 	}
 
-	// Fallback to execFile
-	return execFileCompare(basePath, comparePath, diffOutput, options);
+	if (!baseIsPath || !comparisonIsPath) {
+		throw new Error("Encoded image inputs require the native N-API binding");
+	}
+	return execFileCompare(base, comparison, diffOutput, options);
 }
 
 /** Get the path to the blazediff binary for direct CLI usage. */
@@ -573,8 +606,9 @@ export function hasNativeBinding(): boolean {
 /**
  * Interpret the diff between two images, returning structured analysis results.
  *
- * Uses native N-API bindings when available for better performance.
- * Falls back to execFile if native bindings are unavailable.
+ * Inputs must both be file paths or both be encoded byte arrays. Uses native
+ * N-API bindings when available for better performance. Path inputs fall back
+ * to execFile if native bindings are unavailable.
  *
  * @example
  * ```ts
@@ -586,19 +620,21 @@ export function hasNativeBinding(): boolean {
  * ```
  */
 export async function interpret(
-	image1Path: string,
-	image2Path: string,
+	image1: BlazeDiffInput,
+	image2: BlazeDiffInput,
 	options?: Pick<BlazeDiffOptions, "threshold" | "antialiasing">,
 ): Promise<InterpretResult> {
+	const image1IsPath = typeof image1 === "string";
+	const image2IsPath = typeof image2 === "string";
 	const binding = tryLoadNativeBinding();
-	if (binding) {
-		return binding.interpretImages(image1Path, image2Path, {
+	if (binding && image1IsPath && image2IsPath) {
+		return binding.interpretImages(image1, image2, {
 			threshold: options?.threshold,
 			antialiasing: options?.antialiasing,
 		});
 	}
 
-	const result = await compare(image1Path, image2Path, undefined, {
+	const result = await compare(image1, image2, undefined, {
 		...options,
 		interpret: true,
 	});


### PR DESCRIPTION
**What:** Accept encoded Buffer and Uint8Array inputs in core-native, add a reusable-buffer benchmark, update website and README docs, and include the current landing-page refinements.
**Why:** Enable in-memory screenshot comparison without saving inputs to disk.
**How:** Borrow typed-array backing memory through N-API, decode formats from bytes, and reuse preloaded buffers in benchmarks.
**Notes:** Ref #82.