### PR TITLE
feat(agent): ship image-compare skill

### DIFF
--- a/.changeset/image-compare-skill.md
+++ b/.changeset/image-compare-skill.md
@@ -1,0 +1,5 @@
+---
+"@blazediff/agent": minor
+---
+
+Ship a second skill, `image-compare`, and turn `skill/` into a registry that onboarding installs from. The existing `blazediff` skill only covers visual regression against a running app; comparing two image files already on disk had no entry point, so `blazediff-cli`'s `interpret` was reachable only by someone willing to set up a whole baseline suite. `onboard` now writes every bundled skill for each detected stack — `.claude/skills/<skill>/`, `~/.codex/skills/<skill>/`, `.cursor/rules/<skill>.mdc` — and `installStack` returns one `InstallResult` per skill instead of one per stack. Stack targets take the skill name, `loadSkillFiles(skill)` discovers a skill's files from disk rather than a hardcoded list, and the Cursor rule's `description` is now parsed from the skill's own frontmatter instead of being duplicated in the installer (which also fixes the trigger phrases losing their quotes). The prebuild copy moved to `scripts/copy-skills.mjs` and mirrors `skill/*/` into `packages/agent/skills/*/`.

--- a/packages/agent/.gitignore
+++ b/packages/agent/.gitignore
@@ -1,3 +1,1 @@
-/SKILL.md
-/JUDGING.md
-/MASKING.md
+/skills

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -21,17 +21,15 @@
 	},
 	"files": [
 		"dist",
-		"SKILL.md",
-		"JUDGING.md",
-		"MASKING.md"
+		"skills"
 	],
 	"scripts": {
 		"typecheck": "tsc --noEmit",
-		"prebuild": "node -e \"const {readdirSync,copyFileSync}=require('node:fs');for(const f of readdirSync('../../skill/blazediff'))if(f.endsWith('.md')&&f!=='INSTALL.md')copyFileSync('../../skill/blazediff/'+f,f)\"",
+		"prebuild": "node scripts/copy-skills.mjs",
 		"build": "tsup && vite build",
 		"dev": "tsup --watch",
 		"dev:client": "vite",
-		"clean": "rm -rf dist SKILL.md JUDGING.md MASKING.md",
+		"clean": "rm -rf dist skills",
 		"test": "vitest run --passWithNoTests"
 	},
 	"keywords": [

--- a/packages/agent/scripts/copy-skills.mjs
+++ b/packages/agent/scripts/copy-skills.mjs
@@ -1,0 +1,22 @@
+// Mirrors the repo's skill sources into the package so they ship in the npm
+// tarball. Symlinks would be simpler but do not survive `npm pack` — a link
+// escaping the package root is dropped on extract — so this copies.
+import { cpSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = join(packageDir, "..", "..", "skill");
+const destination = join(packageDir, "skills");
+
+rmSync(destination, { recursive: true, force: true });
+mkdirSync(destination, { recursive: true });
+
+for (const skill of readdirSync(source, { withFileTypes: true })) {
+	if (!skill.isDirectory()) continue;
+	cpSync(join(source, skill.name), join(destination, skill.name), {
+		recursive: true,
+		// INSTALL.md is for humans installing the CLI, not part of the playbook.
+		filter: (path) => !path.endsWith("INSTALL.md"),
+	});
+}

--- a/packages/agent/src/cli/commands/onboard.ts
+++ b/packages/agent/src/cli/commands/onboard.ts
@@ -13,6 +13,7 @@ import {
 	NO_DEV_SCRIPT_ERROR,
 } from "../../onboard/config";
 import { type InstallResult, installStack } from "../../onboard/install";
+import { SKILLS } from "../../onboard/skill-loader";
 import {
 	CODING_AGENT_STACKS,
 	detectStacks,
@@ -44,7 +45,7 @@ async function promptForStacks(): Promise<Stack[]> {
 		...CODING_AGENT_STACKS.map((id) => ({
 			label: STACKS[id].label,
 			value: [id] as Stack[],
-			hint: STACKS[id].target?.(process.cwd()) ?? "",
+			hint: STACKS[id].target?.(process.cwd(), SKILLS[0]) ?? "",
 		})),
 		{ label: "All three coding agents", value: [...CODING_AGENT_STACKS] },
 		{
@@ -184,7 +185,7 @@ function humanizeInstall(results: InstallResult[]): string[] {
 						? "unchanged"
 						: "skipped (exists; --force to overwrite)";
 		const scope = info.scope === "user" ? " [user-global]" : "";
-		return `  ${info.label}: ${verb} ${r.path}${scope}`;
+		return `  ${info.label} /${r.skill}: ${verb} ${r.path}${scope}`;
 	});
 }
 
@@ -281,7 +282,7 @@ export function registerOnboard(program: Command, out: Output): void {
 			const targets = await resolveStacks(opts, interactive);
 			const installed: InstallResult[] = [];
 			for (const t of targets) {
-				installed.push(await installStack(t, cwd, { force: opts.force }));
+				installed.push(...(await installStack(t, cwd, { force: opts.force })));
 			}
 			let judge: JudgeBackend = config?.judge ?? "host";
 			if (targets.length === 0) {

--- a/packages/agent/src/onboard/install.ts
+++ b/packages/agent/src/onboard/install.ts
@@ -1,7 +1,14 @@
 import { readFileSync } from "node:fs";
 import { lstat, mkdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { loadSkillFiles, type SkillFile, skillBodyOnly } from "./skill-loader";
+import {
+	loadSkillFiles,
+	SKILLS,
+	type SkillFile,
+	type SkillName,
+	skillBodyOnly,
+	skillDescription,
+} from "./skill-loader";
 import { STACKS, type Stack, type StackInfo } from "./stacks";
 
 export type InstallStatus =
@@ -13,6 +20,8 @@ export type InstallStatus =
 
 export interface InstallResult {
 	stack: Stack;
+	/** Absent only for local-judge stacks, which install no skill. */
+	skill?: SkillName;
 	path?: string;
 	status: InstallStatus;
 }
@@ -25,9 +34,12 @@ function renderCursorRule(files: SkillFile[]): string {
 	const skill = files.find((f) => f.name === "SKILL.md")?.content ?? "";
 	const sidecars = files.filter((f) => f.name !== "SKILL.md");
 	const body = skillBodyOnly(skill).trim();
+	// JSON.stringify, not hand-quoting: skill descriptions contain double quotes
+	// around their trigger phrases, and a bare YAML double-quoted scalar would
+	// terminate on the first one.
 	const frontmatter = [
 		"---",
-		'description: "Run, author, or update BlazeDiff visual regression tests. Trigger on visual test, screenshot regression, blazediff, /blazediff."',
+		`description: ${JSON.stringify(skillDescription(skill))}`,
 		"alwaysApply: false",
 		"---",
 		"",
@@ -71,39 +83,52 @@ function combineStatuses(statuses: InstallStatus[]): InstallStatus {
 	return "unchanged";
 }
 
-export async function installStack(
+async function installSkill(
 	stack: Stack,
+	info: StackInfo & { kind: "skill-install" },
+	skill: SkillName,
 	cwd: string,
-	opts: { force?: boolean } = {},
+	force: boolean | undefined,
 ): Promise<InstallResult> {
-	const info: StackInfo = STACKS[stack];
-
-	// Local-judge stacks (moondream) install no skill file; onboarding wires the
-	// judge backend into config instead (see the onboard command).
-	if (info.kind === "local-judge") {
-		return { stack, status: "configured" };
-	}
-
-	// `info` narrowed to a skill-install stack above, so these are guaranteed.
-	const target = info.target(cwd);
-	const files = loadSkillFiles();
+	const target = info.target(cwd, skill);
+	const files = loadSkillFiles(skill);
 
 	if (info.format === "cursor-rule") {
-		const content = renderCursorRule(files);
-		const status = await writeIfChanged(target, content, opts.force);
-		return { stack, path: target, status };
+		const status = await writeIfChanged(target, renderCursorRule(files), force);
+		return { stack, skill, path: target, status };
 	}
 
 	const targetDir = dirname(target);
 	const statuses: InstallStatus[] = [];
 	for (const file of files) {
-		const filePath = join(targetDir, file.name);
-		const status = await writeIfChanged(
-			filePath,
-			ensureTrailingNewline(file.content),
-			opts.force,
+		statuses.push(
+			await writeIfChanged(
+				join(targetDir, file.name),
+				ensureTrailingNewline(file.content),
+				force,
+			),
 		);
-		statuses.push(status);
 	}
-	return { stack, path: target, status: combineStatuses(statuses) };
+	return { stack, skill, path: target, status: combineStatuses(statuses) };
+}
+
+/** Installs every bundled skill for one stack — one result per skill. */
+export async function installStack(
+	stack: Stack,
+	cwd: string,
+	opts: { force?: boolean } = {},
+): Promise<InstallResult[]> {
+	const info: StackInfo = STACKS[stack];
+
+	// Local-judge stacks (moondream) install no skill file; onboarding wires the
+	// judge backend into config instead (see the onboard command).
+	if (info.kind === "local-judge") {
+		return [{ stack, status: "configured" }];
+	}
+
+	const results: InstallResult[] = [];
+	for (const skill of SKILLS) {
+		results.push(await installSkill(stack, info, skill, cwd, opts.force));
+	}
+	return results;
 }

--- a/packages/agent/src/onboard/skill-loader.ts
+++ b/packages/agent/src/onboard/skill-loader.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -7,64 +7,92 @@ export interface SkillFile {
 	content: string;
 }
 
-const SKILL_FILES = ["SKILL.md", "JUDGING.md", "MASKING.md"] as const;
+/**
+ * Skills shipped with the agent, in install order. The list is explicit so the
+ * name is a type; the files *within* each skill are discovered, so adding a
+ * sidecar (like JUDGING.md) needs no code change here.
+ */
+export const SKILLS = ["blazediff", "image-compare"] as const;
+export type SkillName = (typeof SKILLS)[number];
 
-let cachedDir: string | null = null;
-let cachedFiles: SkillFile[] | null = null;
+/** Install-time instructions for humans; never shipped into a skill dir. */
+const NOT_A_SKILL_FILE = "INSTALL.md";
+
+let cachedRoot: string | null = null;
+const cachedFiles = new Map<SkillName, SkillFile[]>();
 
 function moduleDir(): string {
 	return dirname(fileURLToPath(import.meta.url));
 }
 
-function resolveSkillDir(): string {
-	if (cachedDir !== null) return cachedDir;
+/**
+ * The directory holding one sub-directory per skill: `skills/` in the published
+ * package (written by the prebuild copy), `skill/` when running from the repo.
+ */
+function resolveSkillsRoot(): string {
+	if (cachedRoot !== null) return cachedRoot;
 	const here = moduleDir();
 	const candidates = [
-		join(here, ".."),
-		join(here, "..", ".."),
-		join(here, "..", "..", "..", "skill", "blazediff"),
-		join(here, "..", "..", "..", "..", "skill", "blazediff"),
+		join(here, "..", "skills"),
+		join(here, "..", "..", "skills"),
+		join(here, "..", "..", "..", "skill"),
+		join(here, "..", "..", "..", "..", "skill"),
 	];
 	for (const dir of candidates) {
-		if (existsSync(join(dir, "SKILL.md"))) {
-			cachedDir = dir;
-			return cachedDir;
+		if (existsSync(join(dir, SKILLS[0], "SKILL.md"))) {
+			cachedRoot = dir;
+			return cachedRoot;
 		}
 	}
 	throw new Error(
-		`could not locate bundled SKILL.md (looked in: ${candidates.join(", ")}). reinstall @blazediff/agent.`,
+		`could not locate bundled skills (looked in: ${candidates.join(", ")}). reinstall @blazediff/agent.`,
 	);
 }
 
-export function loadSkillContent(): string {
-	const dir = resolveSkillDir();
-	return readFileSync(join(dir, "SKILL.md"), "utf8");
+/** SKILL.md first — the cursor-rule renderer treats it as the body. */
+function skillFileOrder(a: string, b: string): number {
+	if (a === "SKILL.md") return -1;
+	if (b === "SKILL.md") return 1;
+	return a.localeCompare(b);
 }
 
-export function loadSkillFiles(): SkillFile[] {
-	if (cachedFiles !== null) return cachedFiles;
-	const dir = resolveSkillDir();
-	cachedFiles = SKILL_FILES.filter((name) => existsSync(join(dir, name))).map(
-		(name) => ({ name, content: readFileSync(join(dir, name), "utf8") }),
-	);
-	return cachedFiles;
+export function loadSkillFiles(skill: SkillName): SkillFile[] {
+	const cached = cachedFiles.get(skill);
+	if (cached !== undefined) return cached;
+
+	const dir = join(resolveSkillsRoot(), skill);
+	const files = readdirSync(dir)
+		.filter((name) => name.endsWith(".md") && name !== NOT_A_SKILL_FILE)
+		.sort(skillFileOrder)
+		.map((name) => ({ name, content: readFileSync(join(dir, name), "utf8") }));
+
+	cachedFiles.set(skill, files);
+	return files;
+}
+
+function frontmatterBounds(lines: string[]): number {
+	if (!lines[0]?.startsWith("---")) return -1;
+	for (let i = 1; i < lines.length; i++) {
+		if (lines[i]?.startsWith("---")) return i;
+	}
+	return -1;
 }
 
 export function skillBodyOnly(content: string): string {
 	const lines = content.split("\n");
-	if (lines[0]?.startsWith("---")) {
-		let end = -1;
-		for (let i = 1; i < lines.length; i++) {
-			if (lines[i]?.startsWith("---")) {
-				end = i;
-				break;
-			}
-		}
-		if (end > 0)
-			return lines
-				.slice(end + 1)
-				.join("\n")
-				.trimStart();
-	}
-	return content;
+	const end = frontmatterBounds(lines);
+	if (end <= 0) return content;
+	return lines
+		.slice(end + 1)
+		.join("\n")
+		.trimStart();
+}
+
+/** The skill's own `description:` — the single source for stack-specific rules. */
+export function skillDescription(content: string): string {
+	const lines = content.split("\n");
+	const end = frontmatterBounds(lines);
+	if (end <= 0) return "";
+	const line = lines.slice(1, end).find((l) => l.startsWith("description:"));
+	return line ? line.slice("description:".length).trim() : "";
 }

--- a/packages/agent/src/onboard/stacks.ts
+++ b/packages/agent/src/onboard/stacks.ts
@@ -16,7 +16,7 @@ interface StackBase {
 export interface SkillInstallStack extends StackBase {
 	kind: "skill-install";
 	detect: (cwd: string) => boolean;
-	target: (cwd: string) => string;
+	target: (cwd: string, skill: string) => string;
 	format: "skill-file" | "cursor-rule";
 	scope: "project" | "user";
 }
@@ -53,7 +53,7 @@ export const STACKS: Record<Stack, StackInfo> = {
 				join(cwd, "CLAUDE.md"),
 				join(cwd, "AGENTS.md"),
 			]),
-		target: (cwd) => join(cwd, ".claude", "skills", "blazediff", "SKILL.md"),
+		target: (cwd, skill) => join(cwd, ".claude", "skills", skill, "SKILL.md"),
 		format: "skill-file",
 		scope: "project",
 	},
@@ -68,7 +68,8 @@ export const STACKS: Record<Stack, StackInfo> = {
 				join(cwd, ".codex"),
 				join(homedir(), ".codex"),
 			]),
-		target: () => join(homedir(), ".codex", "skills", "blazediff", "SKILL.md"),
+		target: (_cwd, skill) =>
+			join(homedir(), ".codex", "skills", skill, "SKILL.md"),
 		format: "skill-file",
 		scope: "user",
 	},
@@ -79,7 +80,7 @@ export const STACKS: Record<Stack, StackInfo> = {
 		judge: "host",
 		detect: (cwd) =>
 			someExists([join(cwd, ".cursor"), join(cwd, ".cursorrules")]),
-		target: (cwd) => join(cwd, ".cursor", "rules", "blazediff.mdc"),
+		target: (cwd, skill) => join(cwd, ".cursor", "rules", `${skill}.mdc`),
 		format: "cursor-rule",
 		scope: "project",
 	},

--- a/skill/blazediff/INSTALL.md
+++ b/skill/blazediff/INSTALL.md
@@ -23,10 +23,12 @@ Paste this file into any coding agent (Claude Code, Codex, Cursor, …) and tell
 
    Verify: `blazediff-agent --version` prints `0.1.2` or later.
 
-2. **Onboard.** Run `blazediff-agent onboard --json`. In one step it writes `.blazediff/config.json`, ensures bundled Chromium is installed (no `npx playwright install`, no `--with-deps`, no sudo — on Linux missing system libs can be fixed later with `npx playwright install-deps chromium`, which the user runs themselves), and writes the bundled playbook to the location for the active stack it detects in `cwd`:
-   - **Claude Code (project-scope):** `<project>/.claude/skills/blazediff/SKILL.md`
-   - **Codex (user-global):** `~/.codex/skills/blazediff/SKILL.md`
-   - **Cursor (project-scope):** `<project>/.cursor/rules/blazediff.mdc` with the right frontmatter
+2. **Onboard.** Run `blazediff-agent onboard --json`. In one step it writes `.blazediff/config.json`, ensures bundled Chromium is installed (no `npx playwright install`, no `--with-deps`, no sudo — on Linux missing system libs can be fixed later with `npx playwright install-deps chromium`, which the user runs themselves), and writes both bundled skills to the location for the active stack it detects in `cwd`:
+   - **Claude Code (project-scope):** `<project>/.claude/skills/<skill>/SKILL.md`
+   - **Codex (user-global):** `~/.codex/skills/<skill>/SKILL.md`
+   - **Cursor (project-scope):** `<project>/.cursor/rules/<skill>.mdc` with the right frontmatter
+
+   Two skills are installed: `blazediff` (visual regression against a running app — capture, check, rebaseline) and `image-compare` (compare two image files already on disk).
 
    Under `--json` it never prompts and never captures. Force a specific subset with `--stack claude,codex,cursor` (or `--stack all`); pass `--force` to overwrite. To judge diffs locally instead of with a host agent, use `--stack local` (installs no skill file; sets `config.judge: "local"` — a two-step Moondream + Qwen pipeline). Skip the Chromium step with `--no-browsers`.
 
@@ -34,7 +36,7 @@ Paste this file into any coding agent (Claude Code, Codex, Cursor, …) and tell
 
 3. **Reload** the host agent's skill list if it supports it (Claude Code: `/reload-plugins`).
 
-4. **Final summary line.** Print exactly: `BlazeDiff installed. Try /blazediff in your agent.`
+4. **Final summary line.** Print exactly: `BlazeDiff installed. Try /blazediff or /image-compare in your agent.`
 
 ## Hard rules
 - Only use `--version` and `onboard --json` during install. Do not capture, check, or rewrite — authoring happens when the user runs `/blazediff`.

--- a/skill/blazediff/SKILL.md
+++ b/skill/blazediff/SKILL.md
@@ -7,6 +7,8 @@ description: Run, author, or update BlazeDiff visual regression tests. Trigger o
 
 CLI binary is `blazediff-agent` (the name `blazediff` belongs to the cargo image-diff binary).
 
+**Not this skill:** comparing two image files already on disk ("what changed between these two PNGs", "did this render drift") → use the `image-compare` skill. This skill is for capturing a running app and managing baselines; it owns `.blazediff/`.
+
 Sibling files in this skill directory — read on demand:
 - `JUDGING.md` — judging ambiguous diffs (`pendingJudgments > 0`) + zsh-safe shell loops for writing verdicts.
 - `MASKING.md` — picking selectors, mass-masking shared noise across routes, applying masks.

--- a/skill/image-compare/SKILL.md
+++ b/skill/image-compare/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: image-compare
+description: Compare two image files on disk and report what changed, region by region. Trigger on "what changed between these two images", "diff these PNGs", "did this render drift", "compare screenshots/exports/renders".
+---
+
+# image-compare
+
+Two image files in, a verdict out. No baselines, no manifest, no browser.
+
+CLI binary is `blazediff-cli` (`npm i -g @blazediff/cli`).
+
+**Not this skill:** capturing a running app, managing baselines, or re-running a
+visual regression suite → use the `blazediff` skill instead (it owns
+`.blazediff/`, `blazediff-agent`, and the check/rewrite loop). If the working
+directory has a `.blazediff/manifest.json` and the user is asking about *routes*
+rather than *files*, you are in the wrong skill.
+
+## Be terse
+- Pass `--json` on every call; parse fields. Do not echo CLI output.
+- Never send whole images to a model when `interpret` has located the regions —
+  see **Send crops, not pages** below. This is the point of the skill.
+- One final summary line: `N regions | <severity> | <one-clause verdict>`.
+
+## Pick the command by the question
+
+| The user is asking | Command | Read from it |
+|---|---|---|
+| "what changed?" / "describe the differences" | `interpret` | `regions[]` — bbox, changeType, position |
+| "are these identical?" | `core-native` | `different pixels` (0 = byte-identical after decode) |
+| "how different, perceptually?" | `ssim` | SSIM score, 1.0 = identical |
+| "did quality degrade?" (compression, resize, generative output) | `msssim` | multi-scale score, 1.0 = identical |
+| "where are the structural differences?" | `gmsd -o map.png` | deviation, **0.0 = identical** |
+
+`interpret` is the default. The others answer *how much*; only `interpret`
+answers *what*.
+
+```
+blazediff-cli interpret a.png b.png --json
+```
+
+Exit codes: `0` no regions, `1` regions found, `2` error. Safe to branch on.
+
+### Picking `--source`
+- `pixel` (default) — pixel-aligned renders: screenshots, PNG exports, chart
+  renders, PDF rasterizations. Anything produced twice by the same renderer.
+- `ms-ssim` / `ssim` — images with resampling or compression noise: JPEGs,
+  camera captures, generative-model output, anything that went through a
+  lossy round-trip. Per-pixel deltas are everywhere in these, so `pixel`
+  returns one giant region; the metric sources threshold a similarity map
+  instead. Their boxes are coarser (map-grid resolution), but the pixel counts
+  inside them are still exact.
+
+Add `-a` when the pair is text-heavy and the only differences are antialiasing
+fringes. Raise `-t` (default 0.1) when the renderer has known per-run jitter.
+
+## Reading the result
+
+```jsonc
+{
+  "summary": "Moderate visual change detected (1.87% of image, 4 regions).",
+  "severity": "medium",           // low | medium | high
+  "diffCount": 30421,             // changed pixels
+  "diffPercentage": 1.87,
+  "totalRegions": 4,
+  "width": 1328, "height": 1228,
+  "regions": [{ "bbox": {...}, "changeType": "...", "position": "...", "shape": "...",
+                "pixelCount": 0, "percentage": 0, "confidence": 0 /* + stats blocks */ }]
+}
+```
+
+`changeType` — `addition`, `deletion`, `content-change`, `color-change`,
+`shift`, `rendering-noise`.
+`position` — `top-left`…`bottom-right`, `top`/`bottom`/`left`/`right`/`center`.
+`shape` — `solid-region`, `mixed-region`, `contour-frame`, `sparse-distributed`,
+`edge-dominated`.
+
+Each region also carries `chroma`, `colorDelta`, `gradient`, `shapeStats`, and
+`signals` blocks. **Do not put these in your context or forward them to a
+model** — they are classifier inputs, not answers. Project each region down to
+`{changeType, position, bbox, percentage}` before you reason about it. The full
+JSON for a 4-region diff is ~7.5 KB; the projection is ~200 tokens.
+
+Interpreting `changeType`:
+- `rendering-noise` — subpixel/antialiasing jitter. Report as "no meaningful
+  change" unless the user is specifically hunting rendering differences.
+- `color-change` with `signals.lowColorDelta` and `gradient.edgeCorrelation`
+  near 1.0 — same content, recoloured. Theme change, not content change.
+- `shift` — content moved, not edited. Say what moved and by roughly how much;
+  don't describe it as added and removed.
+- `addition` / `deletion` / `content-change` — genuine content differences.
+  These are the ones worth cropping and reading.
+
+## Send crops, not pages
+
+When the user wants each change *described* (not just located), crop the
+regions and send only those. Never send the two full images.
+
+Two reasons, and the second matters more than the first:
+
+1. **Cost.** A pair of full-page screenshots is thousands of visual tokens, and
+   nearly all of them show pixels that are identical in both images.
+2. **Legibility.** Claude downscales any image that exceeds the model's limits.
+   A full-page screenshot gets crushed by ~6×, which destroys the exact detail
+   you are trying to compare — and images over 8000 px on an edge are rejected
+   outright.
+
+Measured on this repo's fixtures (Claude Opus 5, high-resolution tier:
+2576 px max edge, 4784 max visual tokens; cost is `⌈w/28⌉ × ⌈h/28⌉` per image):
+
+| | **A**: `fixtures/page` — 3598×16384 page, 2 regions, 0.09% px | **B**: `fixtures/blazediff/3` — 1328×1228, 4 regions, 1.87% px |
+|---|---|---|
+| Both full images, as-is | **rejected** — 16384 px exceeds the 8000 px limit | 2112 ×2 = **4224** tokens |
+| Both pre-resized to fit | 566×2576 → 1932 ×2 = **3864** tokens — but the 711×104 changed region is now **112×16 px**, and the 212×42 one is **33×7 px**. Unreadable. | n/a, already fits |
+| Crops + projected region JSON | 408 + ~128 = **536** | 1178 + ~206 = **1384** |
+| | **7.2× cheaper, at native resolution** | **3.1× cheaper (−67%)** |
+
+The saving scales with how little of the image changed, which for real diffs is
+almost always "very little". Case A changed 0.09% of its pixels; sending both
+pages would have spent ~99.9% of the budget on identical content.
+
+### The crop step
+
+Pad each bbox by 32 px so the change has surrounding context, clamp to the image
+bounds, and crop the **same box from both images** — the pair only reads as a
+before/after if the framing is identical.
+
+```bash
+# one region, both sides. x/y/w/h come from regions[i].bbox, padded and clamped.
+node -e '
+const sharp = require("sharp"), [src, out, x, y, w, h] = process.argv.slice(1);
+sharp(src).extract({left:+x, top:+y, width:+w, height:+h}).toFile(out);
+' "$SRC" "$OUT" "$X" "$Y" "$W" "$H"
+```
+
+`sharp` ships with `@blazediff/cli` via `@blazediff/codec-sharp`. If it does not
+resolve (global install, no local `node_modules`), fall back to `sips -c` on
+macOS or `magick crop` where ImageMagick is present.
+
+Then send, per region, in one message: the region's projected JSON, its before
+crop, its after crop. Label them — `Region 1 (content-change, bottom): before /
+after` — so follow-up questions can name a region without resending anything.
+
+### When not to crop
+
+Send the full (resized) pair instead when any of these hold:
+
+- `totalRegions` is 0 — nothing to crop; answer from the metric score.
+- The regions cover most of the frame (`diffPercentage` above ~25%, or one
+  region spanning most of the bbox area). A full-frame rewrite is best read
+  whole.
+- Summed crop tokens exceed the full-pair cost. With many small scattered
+  regions, per-crop 28-px padding overhead adds up — compute both, pick the
+  smaller.
+- The question is about *layout* or *global composition* rather than local
+  content. Crops destroy spatial relationships between regions.
+
+## Answering
+
+Lead with the verdict, then the regions, in the user's terms:
+
+```
+4 regions changed (medium).
+1. content-change, bottom (590×479 at 356,651) — <what the crops show>
+2. addition, right (95×154 at 992,614) — <what the crops show>
+...
+```
+
+If every region is `rendering-noise`, say the images are visually equivalent and
+give the SSIM score as backing. Don't manufacture a difference to report.
+
+## Failure modes
+
+- **Different dimensions** — `interpret` requires matching sizes. Say so and
+  ask whether to resize or compare a common crop; don't silently resize, since
+  that changes what "different" means.
+- **`pixel` returns one region covering everything** — the pair has resampling
+  or compression noise. Re-run with `--source ms-ssim`.
+- **Huge `diffCount` but the images look the same** — check for an alpha or
+  colour-profile difference; compare with `ssim` (structure-only) to confirm.
+- **`gmsd` output labels are inverted** — the CLI prints
+  `(0=different, 1=identical)` and a `similarity: N%` line, but GMSD is a
+  *deviation*: identical images score `0.000000`. Read the number as distance,
+  and ignore the printed label.


### PR DESCRIPTION
**What:** Adds an `image-compare` skill for diffing two image files on disk, and makes `onboard` install every skill in `skill/` rather than just `blazediff`.

**Why:** `interpret` was only reachable by someone willing to set up a full baseline suite; ad-hoc "what changed between these two PNGs" had no entry point.

**How:** `skill/` became a registry — stack targets take a skill name, `installStack` returns one result per skill, and the Cursor rule's description is parsed from the skill's own frontmatter.

**Notes:** The skill's crop step shells out to a `sharp` one-liner; `prepareRegionReads` in `judge/tiles.ts` already does this and should become `blazediff-cli crop`. Separately, `cli/commands/gmsd.ts:168-176` prints inverted labels — GMSD is a deviation where 0 = identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)