### PR TITLE
fix(ci): bump maturin to 1.15 for rustc 1.98

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -248,9 +248,12 @@ jobs:
       # wheel build needs maturin. The compile fallback is disabled: a source
       # build of maturin trips over yanked transitive deps, and a fast retry
       # of /build beats minutes of doomed compilation.
+      #
+      # The floor is 1.14.1, the first release to bundle cargo-zigbuild 0.23 —
+      # see the version check in crates/scripts/build-maturin.sh for why.
       - name: Install maturin
         if: needs.resolve.outputs.wheels_any == 'true'
-        run: cargo binstall -y --disable-strategies compile maturin@1.13.1
+        run: cargo binstall -y --disable-strategies compile maturin@1.15.0
 
       # cross only backs the linux CLI/.node builds; wheels link with zig.
       - name: Install cross

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       # Pinned to the version build-artifacts.yml ships the released wheels
       # with, so what this imports is what users get.
       - name: Install maturin
-        run: cargo binstall -y --disable-strategies compile maturin@1.13.1
+        run: cargo binstall -y --disable-strategies compile maturin@1.15.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/crates/scripts/build-maturin.sh
+++ b/crates/scripts/build-maturin.sh
@@ -72,6 +72,20 @@ if ! command -v maturin &> /dev/null; then
     exit 1
 fi
 
+# rustc 1.98 started passing `-Wl,--fix-cortex-a53-843419` when linking
+# aarch64-linux, and `zig cc` rejects linker args it doesn't recognise.
+# cargo-zigbuild 0.23 filters it (rust-cross/cargo-zigbuild#452); maturin 1.14.1
+# is the first release to bundle that. Below it, the Linux arm64 wheel dies
+# three minutes into a link with `error: unsupported linker arg`, which names
+# neither maturin nor the toolchain that moved.
+MIN_MATURIN="1.14.1"
+MATURIN_VERSION="$(maturin --version | awk '{print $2}')"
+if [[ "$(printf '%s\n%s\n' "$MIN_MATURIN" "$MATURIN_VERSION" | sort -V | head -1)" != "$MIN_MATURIN" ]]; then
+    echo "Error: maturin $MATURIN_VERSION is too old; $MIN_MATURIN or newer is required."
+    echo "Upgrade with: uv tool install maturin --force"
+    exit 1
+fi
+
 # Maturin's default Windows target uses MSVC ABI (Python on Windows is MSVC-built).
 DEFAULT_TARGETS_MATURIN=(
     aarch64-apple-darwin


### PR DESCRIPTION
**What:** Pin maturin to 1.15.0 in `build-artifacts.yml` and `test.yml`, and add a 1.14.1 floor check to `crates/scripts/build-maturin.sh`.

**Why:** CI's `stable` moved 1.97.1 → 1.98.0 on 2026-08-18, and rustc 1.98 passes `-Wl,--fix-cortex-a53-843419` when linking aarch64-linux, which `zig cc` rejects — the aarch64 wheel was the only failing job in run 32848058120.

**How:** cargo-zigbuild 0.23 filters that arg ([#452](https://github.com/rust-cross/cargo-zigbuild/pull/452)); maturin 1.14.1 is the first release to bundle it.

**Notes:** Reproduced locally with rustc 1.98.0 + maturin 1.13.1, then verified all 18 wheels build across all six targets with 1.15.0. No changeset — CI config only, and the pending Version Packages PR already bumps every family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)