### PR TITLE
fix(ci): don't demand a fresh wasm JS glue

### DIFF
--- a/.github/workflows/release-artifacts-check.yml
+++ b/.github/workflows/release-artifacts-check.yml
@@ -133,8 +133,16 @@ jobs:
 
           if [[ "$wasm" == "true" ]]; then
             # --- WASM ------------------------------------------------------
+            # The module is the freshness proof for this family. Its JS glue is
+            # not: wasm-bindgen derives it from the exported API alone, so a
+            # release that changes the implementation but not the surface
+            # regenerates it byte-for-byte identical, and a content diff cannot
+            # tell that apart from "never rebuilt". Requiring both went red on
+            # the v6.0.1 release for exactly that reason. build-wasm.sh writes
+            # the pair in one invocation, so the module's freshness already
+            # covers the glue.
             require_fresh_file "packages/core-wasm/wasm/blazediff_bg.wasm"
-            require_fresh_file "packages/core-wasm/wasm/blazediff.js"
+            require_file "packages/core-wasm/wasm/blazediff.js"
           fi
 
           if [[ "$ssim" == "true" ]]; then


### PR DESCRIPTION
**What:** `release-artifacts-check` now requires `packages/core-wasm/wasm/blazediff.js` to be present, not to have changed.

**Why:** wasm-bindgen derives the glue from the exported API alone, so a release that changes the implementation but not the surface regenerates it byte-identical — indistinguishable from "never rebuilt" by a content diff. It went red on the v6.0.1 release PR for exactly that.

**How:** `require_fresh_file` → `require_file`; `blazediff_bg.wasm` still carries the freshness proof, and `build-wasm.sh` writes both in one invocation.

**Notes:** Verified by rebuilding wasm locally on rustc 1.98.0 — `blazediff.js`, `blazediff.d.ts` and `blazediff_bg.wasm.d.ts` all reproduce byte-identical to what `/build` committed; only the module differs. Separate latent issue below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)