### PR TITLE
fix(ci): stage every wheels dir on /restore

### DIFF
--- a/.github/workflows/restore-artifacts.yml
+++ b/.github/workflows/restore-artifacts.yml
@@ -111,7 +111,13 @@ jobs:
           # this clone before `git add` sees them.
           git lfs install --local
 
-          git add -A packages crates/blazediff/wheels
+          # Every wheels dir, not just the core one: restore-artifacts.js
+          # rewrites all three, and staging one would drop the other two's
+          # wheels on the floor while still reporting success.
+          git add -A packages \
+            crates/blazediff/wheels \
+            crates/blazediff-ssim/wheels \
+            crates/blazediff-interpret/wheels
           if git diff --cached --quiet; then
             echo "Artifacts already match — nothing to commit."
             echo "committed=false" >> "$GITHUB_OUTPUT"

--- a/scripts/release/restore-artifacts.js
+++ b/scripts/release/restore-artifacts.js
@@ -433,7 +433,7 @@ function main() {
 			DRY_RUN
 				? "\n(dry run — nothing was written)"
 				: "\nNothing is committed. To commit these:\n" +
-						"  git add -A packages crates/blazediff/wheels\n" +
+						`  git add -A packages ${WHEELS_DIRS.join(" ")}\n` +
 						"  git commit --no-verify -m 'build: artifacts for v" +
 						version +
 						"'\n" +


### PR DESCRIPTION
**What:** `/restore` now stages all three `crates/*/wheels` dirs, not just `crates/blazediff/wheels`.

**Why:** #102 gave ssim and interpret their own wheel sets and `restore-artifacts.js` rewrites all three, but the workflow's `git add` was never widened — a restore would drop 12 wheels on the floor and still report success.

**How:** Widen the `git add`, and derive the local-commit hint printed by the script from `WHEELS_DIRS` so the two can't drift again.

**Notes:** Dry-run against build run 32940670411 restores all 46 artifacts, wheels included, across their three independent versions (6.0.1 / 6.1.0 / 6.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)