### PR TITLE
fix(ci): skip -mevex512 in the python test harness

### DIFF
--- a/scripts/checks/test-python.sh
+++ b/scripts/checks/test-python.sh
@@ -19,6 +19,14 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VENV="$ROOT/dist/python-test-venv"
 PYTHON="$VENV/bin/python"
 
+# `_targets.sh` adds -mevex512 to the x86_64 Linux C flags to appease zig's
+# clang, which is how the *released* wheels are cross-built. Everything here is
+# a `--native` build, which never goes through zig, and GCC below 14 — the
+# runner's cc — has no such flag. Same reason benchmark-binary.yml sets it.
+# Overridable for the one case that still needs the flag natively: a host cc
+# that is clang 18 or newer.
+export BLAZEDIFF_SKIP_EVEX512="${BLAZEDIFF_SKIP_EVEX512:-1}"
+
 CRATES=(blazediff blazediff-ssim blazediff-interpret)
 
 for tool in uv maturin; do


### PR DESCRIPTION
**What:** `scripts/checks/test-python.sh` now defaults `BLAZEDIFF_SKIP_EVEX512=1`.

**Why:** `_targets.sh` adds `-mevex512` to the x86_64-linux C flags to appease zig's clang, but this harness only does `--native` builds, which never go through zig — and the runner's GCC 13 has no such flag, so libdeflate-sys failed to compile on PR #103.

**How:** Same escape hatch `benchmark-binary.yml` already uses for its native build; left overridable for a host `cc` that is clang 18 or newer.

**Notes:** Verified the flag is suppressed only when the var is set, so the cross-built released wheels still get it. `pnpm test:python` still 35/35 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)