### PR TITLE
feat: live fixture picker for interpret demo

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -32,6 +32,7 @@
 			"@blazediff/interpret-native-linux-x64",
 			"@blazediff/interpret-native-win32-arm64",
 			"@blazediff/interpret-native-win32-x64",
+			"@blazediff/interpret-wasm",
 			"@blazediff/rust-interpret"
 		]
 	],

--- a/.changeset/pink-donkeys-tickle.md
+++ b/.changeset/pink-donkeys-tickle.md
@@ -1,0 +1,20 @@
+---
+"@blazediff/interpret-native": minor
+"@blazediff/rust-interpret": minor
+---
+
+Add `@blazediff/interpret-wasm`, a wasm32 build of the interpret classifier for
+browsers and any other wasm host, and make region ordering deterministic.
+
+The new package mirrors `@blazediff/core-wasm`: a buffers-only `interpret()`
+over RGBA8 input, no bundled codecs, and the same result shape
+`@blazediff/interpret-native` returns. It is backed by a new `wasm` feature on
+the `blazediff-interpret` crate, which required making the crate's image I/O
+optional — `io` is now its own feature that `napi`, `python` and `cli` enable,
+so the wasm build links none of the vendored C.
+
+`extract_labeled_regions` keyed its components by a `HashMap` and iterated it,
+so two regions with equal `pixelCount` came back in a per-process random order.
+That leaked into `regions` and into the summary's position list, making
+identical inputs produce different output between runs. It is now a `BTreeMap`,
+so ties resolve in raster order.

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -61,6 +61,7 @@ jobs:
       ssim: ${{ steps.families.outputs.ssim }}
       interpret: ${{ steps.families.outputs.interpret }}
       wasm: ${{ steps.families.outputs.wasm }}
+      wasm_interpret: ${{ steps.families.outputs.wasm_interpret }}
       core_version: ${{ steps.version.outputs.core_version }}
       ssim_version: ${{ steps.version.outputs.ssim_version }}
       interpret_version: ${{ steps.version.outputs.interpret_version }}
@@ -179,6 +180,9 @@ jobs:
           fi
           if [[ "${{ steps.families.outputs.wasm }}" == "true" ]]; then
             parts+=("wasm v$(pkg_version packages/core-wasm)")
+          fi
+          if [[ "${{ steps.families.outputs.wasm_interpret }}" == "true" ]]; then
+            parts+=("interpret-wasm v$(pkg_version packages/interpret-wasm)")
           fi
           if [[ "$WHEELS_CORE" == "true" ]]; then
             parts+=("blazediff wheels v$CORE_VER")
@@ -403,14 +407,31 @@ jobs:
             crates/blazediff-ssim/wheels/*.whl
             crates/blazediff-interpret/wheels/*.whl
 
+  # Both wasm packages build the same way — same target, same toolchain, same
+  # post-processing — so they share one job definition and differ only in which
+  # crate shim runs. Each leg is gated on its own family, so an interpret-only
+  # change doesn't rebuild the core module.
   wasm:
-    name: wasm32-unknown-unknown
+    name: wasm32-unknown-unknown (${{ matrix.artifact }})
     needs: resolve
-    if: needs.resolve.outputs.wasm == 'true'
+    if: needs.resolve.outputs.wasm == 'true' || needs.resolve.outputs.wasm_interpret == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - artifact: wasm
+            family: wasm
+            crate: blazediff
+            pkg: core-wasm
+          - artifact: interpret-wasm
+            family: wasm_interpret
+            crate: blazediff-interpret
+            pkg: interpret-wasm
     steps:
       - uses: actions/checkout@v5
+        if: needs.resolve.outputs[matrix.family] == 'true'
         with:
           ref: ${{ needs.resolve.outputs.sha }}
           # No submodules: the wasm build runs --no-default-features --features
@@ -419,19 +440,24 @@ jobs:
           lfs: false
 
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.resolve.outputs[matrix.family] == 'true'
         with:
           targets: wasm32-unknown-unknown
 
       - uses: cargo-bins/cargo-binstall@main
+        if: needs.resolve.outputs[matrix.family] == 'true'
 
-      # Must match the wasm-bindgen pin in crates/blazediff/Cargo.toml and the
-      # default in build-wasm.sh; the CLI errors out on a mismatch.
+      # Must match the wasm-bindgen pin in the crate's Cargo.toml and the
+      # default in crates/scripts/build-wasm.sh; the CLI errors out on a
+      # mismatch.
       - name: Install wasm-bindgen-cli
+        if: needs.resolve.outputs[matrix.family] == 'true'
         run: cargo binstall -y wasm-bindgen-cli@0.2.100
 
       # build-wasm.sh silently skips wasm-opt when it is absent, which would
       # commit an unoptimized module.
       - name: Install binaryen (wasm-opt)
+        if: needs.resolve.outputs[matrix.family] == 'true'
         run: |
           set -euo pipefail
           sudo apt-get update
@@ -439,17 +465,19 @@ jobs:
           wasm-opt --version
 
       - name: Build wasm
-        run: crates/blazediff/scripts/build-wasm.sh
+        if: needs.resolve.outputs[matrix.family] == 'true'
+        run: crates/${{ matrix.crate }}/scripts/build-wasm.sh
 
       # Single directory, so the archive root is that directory — the commit job
-      # downloads it straight back into packages/core-wasm/wasm/.
+      # downloads it straight back into packages/<pkg>/wasm/.
       - uses: actions/upload-artifact@v4
+        if: needs.resolve.outputs[matrix.family] == 'true'
         with:
-          name: wasm
+          name: ${{ matrix.artifact }}
           if-no-files-found: error
           # Matches the target uploads; restore needs the whole set or none.
           retention-days: 14
-          path: packages/core-wasm/wasm/
+          path: packages/${{ matrix.pkg }}/wasm/
 
   commit:
     name: Commit to PR
@@ -501,6 +529,12 @@ jobs:
         with:
           name: wasm
           path: packages/core-wasm/wasm
+
+      - uses: actions/download-artifact@v4
+        if: needs.resolve.outputs.wasm_interpret == 'true'
+        with:
+          name: interpret-wasm
+          path: packages/interpret-wasm/wasm
 
       - name: Stage artifacts
         run: |

--- a/.github/workflows/release-artifacts-check.yml
+++ b/.github/workflows/release-artifacts-check.yml
@@ -11,8 +11,9 @@ name: release-artifacts-check
 #   2. This check goes red — artifacts are stale or missing.
 #   3. Maintainer comments `/build` on the PR; build-artifacts.yml rebuilds
 #      every platform on GitHub runners and pushes the artifacts to the branch.
-#      (Locally that is: pnpm build:rust, build:rust:ssim, build:wasm and the
-#      build:python:*:all scripts with -- --version <NEW>, committed and pushed.)
+#      (Locally that is: pnpm build:rust, build:rust:ssim, build:wasm,
+#      build:wasm:interpret and the build:python:*:all scripts with
+#      -- --version <NEW>, committed and pushed.)
 #   4. Check turns green; PR is mergeable; merge fires release.yml.
 
 on:
@@ -73,7 +74,7 @@ jobs:
           # build-artifacts.yml, keeping what /build produces aligned with
           # what this check requires.
           eval "$(node scripts/release/changed-artifacts.js "$BASE_SHA")"
-          echo "families needing fresh artifacts: core=$core ssim=$ssim interpret=$interpret wasm=$wasm"
+          echo "families needing fresh artifacts: core=$core ssim=$ssim interpret=$interpret wasm=$wasm wasm_interpret=$wasm_interpret"
 
           # With per-family version groups there is no all-bump safety net:
           # crate sources changed without a changeset would ship stale
@@ -145,6 +146,13 @@ jobs:
             require_file "packages/core-wasm/wasm/blazediff.js"
           fi
 
+          if [[ "$wasm_interpret" == "true" ]]; then
+            # --- INTERPRET WASM --------------------------------------------
+            # Same module-is-the-proof reasoning as the core wasm block above.
+            require_fresh_file "packages/interpret-wasm/wasm/blazediff_interpret_bg.wasm"
+            require_file "packages/interpret-wasm/wasm/blazediff_interpret.js"
+          fi
+
           if [[ "$ssim" == "true" ]]; then
             # --- SSIM NAPI .node -------------------------------------------
             for plat in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-arm64 win32-x64; do
@@ -179,6 +187,7 @@ jobs:
             if [[ "$ssim" == "true" ]]; then echo "  pnpm build:rust:ssim"; fi
             if [[ "$interpret" == "true" ]]; then echo "  pnpm build:rust:interpret"; fi
             if [[ "$wasm" == "true" ]]; then echo "  pnpm build:wasm"; fi
+            if [[ "$wasm_interpret" == "true" ]]; then echo "  pnpm build:wasm:interpret"; fi
             echo "  pnpm build:python:all -- --version ${CORE_VER}"
             echo "  pnpm build:python:ssim:all -- --version ${SSIM_VER}"
             echo "  pnpm build:python:interpret:all -- --version ${INTERPRET_VER}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Monorepo for image and object diffing. pnpm workspaces. Rust core in `crates/bla
 - Benchmark scripts and fixture names: `package.json` and `apps/*-benchmark/`.
 - Agent design + roadmap: `packages/agent/ROADMAP.md`.
 - Agent on-disk shape, mask semantics, judge handoff: `skill/blazediff/SKILL.md`.
-- Rust build orchestration: `crates/scripts/` (`_targets.sh`, `build-napi.sh`, `build-maturin.sh`) with per-crate shims in `crates/<crate>/scripts/`; `build-all.sh` and `build-wasm.sh` stay in `crates/blazediff/scripts/`.
+- Rust build orchestration: `crates/scripts/` (`_targets.sh`, `build-napi.sh`, `build-maturin.sh`, `build-wasm.sh`) with per-crate shims in `crates/<crate>/scripts/`; only `build-all.sh` stays in `crates/blazediff/scripts/`.
 - Python release: `scripts/release/publish-pypi.js` (three wheel sets committed to `crates/{blazediff,blazediff-ssim,blazediff-interpret}/wheels/`, CI uploads via OIDC). `pnpm test:python` builds and imports them.
 - JSR release: `scripts/release/publish-jsr.ts` (chained after `changeset publish` in `pnpm run release`).
 - Pre-commit: `.pre-commit-config.yaml` (prek). Run `npx @j178/prek install` after clone.

--- a/apps/website/app/docs/difference-analysis/page.mdx
+++ b/apps/website/app/docs/difference-analysis/page.mdx
@@ -7,8 +7,6 @@ description: BlazeDiff interpret mode turns a raw pixel diff into labelled regio
 
 import { Tabs } from "nextra/components";
 import InterpretComparison from "../../../components/interpret-comparison";
-import diffData from "../../../data/interpret/blazediff-3-diff.json";
-import identicalData from "../../../data/interpret/blazediff-3-identical.json";
 
 **Interpret mode takes a raw pixel diff and tells you what changed, where, and how
 much.** Instead of one number, you get a list of regions, each with a bounding
@@ -55,13 +53,10 @@ that were measured deterministically is answering a much easier question. See
    the content that appeared at another — by directly correlating the two image
    crops, scored best-first — and relabels both halves as a Shift.
 
-## Demo
+Pick a fixture pair. The analysis runs in your browser, in a Web Worker, on the
+same Rust classifier compiled to wasm — nothing here is precomputed.
 
-<InterpretComparison
-  fixtureA="https://raw.githubusercontent.com/teimurjan/blazediff/refs/heads/main/fixtures/blazediff/3a.png"
-  fixtureB="https://raw.githubusercontent.com/teimurjan/blazediff/refs/heads/main/fixtures/blazediff/3b.png"
-  fullResult={diffData}
-/>
+<InterpretComparison />
 
 ## Usage
 
@@ -117,11 +112,7 @@ Exits 0 when nothing actionable changed, 1 when it did, 2 on error.
 
 ### Identical images
 
-<InterpretComparison
-  fixtureA="https://raw.githubusercontent.com/teimurjan/blazediff/refs/heads/main/fixtures/blazediff/3a.png"
-  fixtureB="https://raw.githubusercontent.com/teimurjan/blazediff/refs/heads/main/fixtures/blazediff/3a.png"
-  fullResult={identicalData}
-/>
+<InterpretComparison pairIds={["blazediff/3-identical"]} />
 
 When nothing changed, `regions` is empty and `summary` says so.
 

--- a/apps/website/components/demos/shared.ts
+++ b/apps/website/components/demos/shared.ts
@@ -1,7 +1,8 @@
 // Shared fixtures + class props so the React and vanilla demos render identically.
 
-const RAW =
-	"https://raw.githubusercontent.com/teimurjan/blazediff/refs/heads/main/fixtures/blazediff";
+import { RAW_FIXTURES } from "../../utils/fixtures";
+
+const RAW = `${RAW_FIXTURES}/blazediff`;
 
 export const A = `${RAW}/1a.png`;
 export const B = `${RAW}/1b.png`;

--- a/apps/website/components/interpret-comparison.tsx
+++ b/apps/website/components/interpret-comparison.tsx
@@ -1,7 +1,22 @@
 "use client";
 
-import Image from "next/image";
-import { useState } from "react";
+import type { InterpretResult } from "@blazediff/interpret-wasm";
+import { IconChevronDown } from "@tabler/icons-react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import type {
+	InterpretPhase,
+	InterpretRequest,
+	InterpretResponse,
+} from "./interpret.worker";
+import {
+	DEFAULT_PAIR_ID,
+	type FixturePair,
+	findPair,
+	groupPairs,
+	INTERPRET_FIXTURES,
+	isHeavy,
+	megapixels,
+} from "./interpret-fixtures";
 import InterpretSummary from "./interpret-summary";
 
 interface BoundingBox {
@@ -11,30 +26,31 @@ interface BoundingBox {
 	height: number;
 }
 
-interface ChangeRegion {
-	bbox: BoundingBox;
-	pixelCount: number;
-	percentage: number;
-	position: string;
-	shape: string;
-	changeType: string;
-	confidence: number;
-}
-
-interface InterpretResult {
-	summary: string;
-	totalRegions: number;
-	regions: ChangeRegion[];
-	severity: string;
-	diffPercentage: number;
-	width: number;
-	height: number;
-}
-
 interface InterpretComparisonProps {
-	fixtureA: string;
-	fixtureB: string;
-	fullResult: InterpretResult;
+	/** Which fixtures to offer. One id renders no select. */
+	pairIds?: string[];
+	/** Which of them to open on. */
+	defaultId?: string;
+}
+
+/**
+ * The published wasm module, pinned to the version this checkout ships (see
+ * the note in next.config.mjs for why it comes off a CDN rather than the
+ * bundle). jsDelivr serves it as `application/wasm` with `access-control-
+ * allow-origin: *`, which is what lets the worker stream it cross-origin.
+ */
+const WASM_URL = `https://cdn.jsdelivr.net/npm/@blazediff/interpret-wasm@${process.env.NEXT_PUBLIC_INTERPRET_WASM_VERSION}/wasm/blazediff_interpret_bg.wasm`;
+
+const PHASE_LABEL: Record<InterpretPhase, string> = {
+	fetching: "Fetching images",
+	decoding: "Decoding",
+	analyzing: "Analyzing",
+};
+
+/** `content-change` -> `Content change`. */
+function humanize(value: string): string {
+	const spaced = value.replace(/-/g, " ");
+	return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 }
 
 function RegionHighlight({
@@ -60,115 +76,287 @@ function RegionHighlight({
 	);
 }
 
+function Pane({
+	pair,
+	src,
+	caption,
+	bbox,
+}: {
+	pair: FixturePair;
+	src: string;
+	caption: string;
+	bbox: BoundingBox | null;
+}) {
+	return (
+		<div>
+			{/*
+			  A plain <img>, not next/image: these are up to 3598x16384, and
+			  routing them through the optimizer would decode ~236 MB in sharp
+			  per request. The wrapper carries the true aspect ratio so the
+			  percentage-positioned overlay lands on the right pixels.
+			*/}
+			<div
+				className="relative overflow-hidden rounded-lg"
+				style={{ aspectRatio: `${pair.width} / ${pair.height}` }}
+			>
+				{/* biome-ignore lint/performance/noImgElement: see above */}
+				<img src={src} alt={caption} className="w-full" loading="lazy" />
+				{bbox && (
+					<RegionHighlight
+						bbox={bbox}
+						imageWidth={pair.width}
+						imageHeight={pair.height}
+					/>
+				)}
+			</div>
+			<p className="text-sm text-gray-600 mt-2 text-center">{caption}</p>
+		</div>
+	);
+}
+
 export default function InterpretComparison({
-	fixtureA,
-	fixtureB,
-	fullResult,
+	pairIds,
+	defaultId,
 }: InterpretComparisonProps) {
+	const selectId = useId();
+
+	const pairs = (pairIds ?? INTERPRET_FIXTURES.map((pair) => pair.id))
+		.map(findPair)
+		.filter((pair): pair is FixturePair => pair !== undefined);
+
+	const [pairId, setPairId] = useState(
+		defaultId ?? (pairIds ? pairs[0]?.id : DEFAULT_PAIR_ID) ?? "",
+	);
+	const [result, setResult] = useState<InterpretResult | null>(null);
+	const [phase, setPhase] = useState<InterpretPhase | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [gated, setGated] = useState(false);
 	const [jsonExpanded, setJsonExpanded] = useState(false);
 	const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
+	const workerRef = useRef<Worker | null>(null);
+
+	const pair = findPair(pairId) ?? pairs[0];
+
+	const stopWorker = useCallback(() => {
+		// wasm linear memory never shrinks, so a worker that has analyzed a
+		// 59 MP pair holds on to ~1 GB for the life of the page. Terminating is
+		// both how we cancel and how we give that back.
+		workerRef.current?.terminate();
+		workerRef.current = null;
+	}, []);
+
+	const run = useCallback(
+		(target: FixturePair) => {
+			stopWorker();
+			setResult(null);
+			setError(null);
+			setGated(false);
+			setHoveredIndex(null);
+			setPhase("fetching");
+
+			const worker = new Worker(
+				new URL("./interpret.worker.ts", import.meta.url),
+				{ type: "module" },
+			);
+			workerRef.current = worker;
+
+			worker.onmessage = (event: MessageEvent<InterpretResponse>) => {
+				const message = event.data;
+				if (message.type === "phase") {
+					setPhase(message.phase);
+					return;
+				}
+				if (message.type === "done") {
+					setResult(message.result);
+				} else {
+					setError(message.message);
+				}
+				setPhase(null);
+				stopWorker();
+			};
+
+			worker.onerror = (event) => {
+				setError(event.message || "the analysis worker failed to start");
+				setPhase(null);
+				stopWorker();
+			};
+
+			worker.postMessage({
+				a: target.a,
+				b: target.b,
+				width: target.width,
+				height: target.height,
+				wasmUrl: WASM_URL,
+			} satisfies InterpretRequest);
+		},
+		[stopWorker],
+	);
+
+	useEffect(() => {
+		if (!pair) return;
+
+		// The heavy pairs cost tens of megabytes and roughly a gigabyte of wasm
+		// memory. Make the reader ask for those rather than spending it on a
+		// stray keystroke in the select.
+		if (isHeavy(pair)) {
+			stopWorker();
+			setResult(null);
+			setError(null);
+			setPhase(null);
+			setGated(true);
+			return;
+		}
+
+		run(pair);
+		return stopWorker;
+	}, [pair, run, stopWorker]);
+
 	const hoveredBbox =
-		hoveredIndex !== null && hoveredIndex < fullResult.regions.length
-			? fullResult.regions[hoveredIndex].bbox
+		result && hoveredIndex !== null && hoveredIndex < result.regions.length
+			? result.regions[hoveredIndex].bbox
 			: null;
 
 	return (
 		<div className="space-y-4">
-			<div className="grid grid-cols-2 gap-4">
-				<div>
-					<div className="relative overflow-hidden rounded-lg">
-						<Image
-							src={fixtureA}
-							alt="Image 1"
-							className="w-full"
-							width={400}
-							height={400}
-						/>
-						{hoveredBbox && (
-							<RegionHighlight
-								bbox={hoveredBbox}
-								imageWidth={fullResult.width}
-								imageHeight={fullResult.height}
-							/>
-						)}
-					</div>
-					<p className="text-sm text-gray-600 mt-2 text-center">Image 1</p>
+			{pairs.length > 1 && (
+				<div className="relative w-full">
+					<label htmlFor={selectId} className="sr-only">
+						Fixture pair
+					</label>
+					<select
+						id={selectId}
+						value={pairId}
+						onChange={(event) => setPairId(event.target.value)}
+						className="w-full appearance-none rounded-lg border border-line bg-surface px-3 py-2 pr-10 font-mono text-sm text-fg transition-colors hover:border-accent/60 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/40"
+					>
+						{groupPairs(pairs).map(([group, groupItems]) => (
+							<optgroup key={group} label={group}>
+								{groupItems.map((item) => (
+									<option key={item.id} value={item.id}>
+										{item.id} — {item.label} ({item.width}×{item.height})
+									</option>
+								))}
+							</optgroup>
+						))}
+					</select>
+					<IconChevronDown
+						size={16}
+						className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted"
+					/>
 				</div>
-				<div>
-					<div className="relative overflow-hidden rounded-lg">
-						<Image
-							src={fixtureB}
-							alt="Image 2"
-							className="w-full"
-							width={400}
-							height={400}
-						/>
-						{hoveredBbox && (
-							<RegionHighlight
-								bbox={hoveredBbox}
-								imageWidth={fullResult.width}
-								imageHeight={fullResult.height}
-							/>
-						)}
-					</div>
-					<p className="text-sm text-gray-600 mt-2 text-center">Image 2</p>
+			)}
+
+			{pair && (
+				<div className="grid grid-cols-2 gap-4 max-h-[30rem] overflow-y-auto">
+					<Pane pair={pair} src={pair.a} caption="Image 1" bbox={hoveredBbox} />
+					<Pane pair={pair} src={pair.b} caption="Image 2" bbox={hoveredBbox} />
 				</div>
-			</div>
+			)}
 
 			<div className="space-y-4">
-				<InterpretSummary
-					severity={fullResult.severity}
-					diffPercentage={fullResult.diffPercentage}
-				>
-					<p className="text-sm whitespace-pre-line">{fullResult.summary}</p>
-				</InterpretSummary>
-
-				{fullResult.regions.length > 0 && (
-					<div className="space-y-2 max-h-96 overflow-y-auto">
-						<p className="text-sm font-medium flex items-center gap-2 justify-between">
-							<span>Regions ({fullResult.regions.length})</span>
-							<span className="text-gray-500">Hover a region to highlight</span>
+				{gated && pair && (
+					<div className="p-4 rounded-lg bg-gray-100 dark:bg-gray-800 space-y-3">
+						<p className="text-sm">
+							This pair is {megapixels(pair).toFixed(1)} MP. Analysis runs in a
+							Web Worker in your browser and will take several seconds and
+							roughly a gigabyte of memory.
 						</p>
-						{fullResult.regions.map((region, i) => (
-							// biome-ignore lint/a11y/noStaticElementInteractions: hover highlight
-							<div
-								key={`${region.position}-${i}`}
-								className={`p-3 rounded-lg border text-sm cursor-pointer transition-colors ${hoveredIndex === i ? "border-blue-400 bg-blue-50 dark:bg-blue-950/30" : "border-gray-200 dark:border-gray-700"}`}
-								onMouseEnter={() => setHoveredIndex(i)}
-								onMouseLeave={() => setHoveredIndex(null)}
-							>
-								<div className="flex items-center gap-2 flex-wrap">
-									<span className="font-medium">{region.position}</span>
-									<span className="text-gray-500">·</span>
-									<span>{region.changeType}</span>
-									<span className="text-gray-500">·</span>
-									<span className="text-gray-500">{region.shape}</span>
-									<span className="text-gray-500">·</span>
-									<span className="text-xs text-gray-400">
-										({region.bbox.x}, {region.bbox.y}, {region.bbox.width}×
-										{region.bbox.height}) · {region.percentage.toFixed(2)}%
-									</span>
-								</div>
-							</div>
-						))}
+						<button
+							type="button"
+							onClick={() => run(pair)}
+							className="rounded-lg border border-accent px-3 py-1.5 text-sm text-accent transition-colors hover:bg-accent hover:text-canvas"
+						>
+							Analyze anyway
+						</button>
 					</div>
 				)}
 
-				<div>
-					<button
-						type="button"
-						onClick={() => setJsonExpanded(!jsonExpanded)}
-						className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
-					>
-						{jsonExpanded ? "Hide" : "Show"} raw JSON
-					</button>
-					{jsonExpanded && (
-						<pre className="mt-2 p-3 rounded-lg bg-gray-100 dark:bg-gray-800 text-xs overflow-x-auto max-h-80">
-							{JSON.stringify(fullResult, null, 2)}
-						</pre>
-					)}
-				</div>
+				{phase && pair && (
+					<div className="p-4 rounded-lg bg-gray-100 dark:bg-gray-800">
+						<p className="font-mono text-sm text-gray-500">
+							{PHASE_LABEL[phase]} {pair.width}×{pair.height}…
+						</p>
+					</div>
+				)}
+
+				{error && (
+					<div className="p-4 rounded-lg border border-red-500/40 bg-red-50 dark:bg-red-950/20 space-y-3">
+						<p className="text-sm">{error}</p>
+						{pair && (
+							<button
+								type="button"
+								onClick={() => run(pair)}
+								className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+							>
+								Retry
+							</button>
+						)}
+					</div>
+				)}
+
+				{result && (
+					<>
+						<InterpretSummary
+							severity={result.severity}
+							diffPercentage={result.diffPercentage}
+						>
+							<p className="text-sm whitespace-pre-line">{result.summary}</p>
+						</InterpretSummary>
+
+						{result.regions.length > 0 && (
+							<div className="space-y-2 max-h-96 overflow-y-auto">
+								<p className="text-sm font-medium flex items-center gap-2 justify-between">
+									<span>Regions ({result.regions.length})</span>
+									<span className="text-gray-500">
+										Hover a region to highlight
+									</span>
+								</p>
+								{result.regions.map((region, i) => (
+									// biome-ignore lint/a11y/noStaticElementInteractions: hover highlight
+									<div
+										key={`${region.position}-${i}`}
+										className={`p-3 rounded-lg border text-sm cursor-pointer transition-colors ${hoveredIndex === i ? "border-blue-400 bg-blue-50 dark:bg-blue-950/30" : "border-gray-200 dark:border-gray-700"}`}
+										onMouseEnter={() => setHoveredIndex(i)}
+										onMouseLeave={() => setHoveredIndex(null)}
+									>
+										<div className="flex items-center gap-2 flex-wrap">
+											<span className="font-medium">
+												{humanize(region.position)}
+											</span>
+											<span className="text-gray-500">·</span>
+											<span>{humanize(region.changeType)}</span>
+											<span className="text-gray-500">·</span>
+											<span className="text-gray-500">
+												{humanize(region.shape)}
+											</span>
+											<span className="text-gray-500">·</span>
+											<span className="text-xs text-gray-400">
+												({region.bbox.x}, {region.bbox.y}, {region.bbox.width}×
+												{region.bbox.height}) · {region.percentage.toFixed(2)}%
+											</span>
+										</div>
+									</div>
+								))}
+							</div>
+						)}
+
+						<div>
+							<button
+								type="button"
+								onClick={() => setJsonExpanded(!jsonExpanded)}
+								className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+							>
+								{jsonExpanded ? "Hide" : "Show"} raw JSON
+							</button>
+							{jsonExpanded && (
+								<pre className="mt-2 p-3 rounded-lg bg-gray-100 dark:bg-gray-800 text-xs overflow-x-auto max-h-80">
+									{JSON.stringify(result, null, 2)}
+								</pre>
+							)}
+						</div>
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/website/components/interpret-fixtures.ts
+++ b/apps/website/components/interpret-fixtures.ts
@@ -1,0 +1,143 @@
+import { fixtureUrl } from "../utils/fixtures";
+
+export interface FixturePair {
+	/** `"<group>/<n>"`, stable across renders and used as the select value. */
+	id: string;
+	/** Fixture directory; doubles as the `<optgroup>` label. */
+	group: string;
+	/** What the pair demonstrates, shown in the option. */
+	label: string;
+	a: string;
+	b: string;
+	/**
+	 * Intrinsic dimensions, hardcoded because the files are committed and
+	 * static. Knowing them before any byte is fetched is what lets the preview
+	 * reserve the right aspect ratio and the heavy-pair gate fire up front.
+	 */
+	width: number;
+	height: number;
+}
+
+interface Spec {
+	n: number;
+	label: string;
+	width: number;
+	height: number;
+}
+
+function pairs(group: string, extension: string, specs: Spec[]): FixturePair[] {
+	return specs.map(({ n, label, width, height }) => ({
+		id: `${group}/${n}`,
+		group,
+		label,
+		a: fixtureUrl(group, `${n}a.${extension}`),
+		b: fixtureUrl(group, `${n}b.${extension}`),
+		width,
+		height,
+	}));
+}
+
+/**
+ * Every fixture pair the browser can actually analyze, cheapest first.
+ *
+ * `fixtures/4k-qoi` is left out because no browser decodes QOI, and
+ * `fixtures/4k` because its PNGs run 15-29 MB each — `fixtures/4k-jpeg` holds
+ * the same three scenes at a tenth of the weight.
+ */
+export const INTERPRET_FIXTURES: FixturePair[] = [
+	...pairs("blazediff", "png", [
+		{ n: 1, label: "UI banner, text edit", width: 1468, height: 294 },
+		{ n: 2, label: "Card, small layout shift", width: 552, height: 636 },
+		{ n: 3, label: "Landing page, mixed edits", width: 1328, height: 1228 },
+		{ n: 4, label: "Tall page, content swap", width: 1320, height: 2868 },
+	]),
+	...pairs("pixelmatch", "png", [
+		{ n: 1, label: "Classic pixelmatch pair", width: 512, height: 256 },
+		{ n: 2, label: "Photo, compression noise", width: 256, height: 256 },
+		{ n: 3, label: "Anti-aliased edges", width: 512, height: 256 },
+		{ n: 4, label: "Map tile", width: 438, height: 412 },
+		{ n: 5, label: "Gradient", width: 256, height: 256 },
+		{ n: 6, label: "Sub-pixel text", width: 256, height: 256 },
+		{ n: 7, label: "Chart", width: 500, height: 500 },
+	]),
+	...pairs("alpha", "png", [
+		{ n: 1, label: "Transparency", width: 192, height: 192 },
+	]),
+	...pairs("same", "png", [
+		{
+			n: 1,
+			label: "Identical pixels, different metadata",
+			width: 1498,
+			height: 1160,
+		},
+	]),
+	...pairs("4k-jpeg", "jpg", [
+		{ n: 1, label: "4K photo (17.9 MP)", width: 5600, height: 3200 },
+		{ n: 2, label: "4K photo (20.0 MP)", width: 5472, height: 3648 },
+		{ n: 3, label: "4K photo (24.0 MP)", width: 6000, height: 4000 },
+	]),
+	...pairs("page", "png", [
+		{
+			n: 1,
+			label: "Full-page screenshot (58.9 MP)",
+			width: 3598,
+			height: 16384,
+		},
+		{
+			n: 2,
+			label: "Full-page screenshot (41.7 MP)",
+			width: 3000,
+			height: 13904,
+		},
+	]),
+];
+
+/** The pair the demo opens on — small, and rich enough to show every column. */
+export const DEFAULT_PAIR_ID = "blazediff/3";
+
+/**
+ * An image against itself. Not in the list above: it is the worked example for
+ * the "nothing changed" case rather than something to browse to.
+ */
+export const IDENTICAL_PAIR: FixturePair = {
+	id: "blazediff/3-identical",
+	group: "blazediff",
+	label: "Identical images",
+	a: fixtureUrl("blazediff", "3a.png"),
+	b: fixtureUrl("blazediff", "3a.png"),
+	width: 1328,
+	height: 1228,
+};
+
+/**
+ * Above this, analysis is gated behind an explicit click. A 25 MP pair already
+ * means ~100 MB of RGBA per image and several seconds of work; the two `page`
+ * fixtures go well past that.
+ */
+export const HEAVY_MEGAPIXELS = 25;
+
+export const megapixels = (pair: FixturePair) =>
+	(pair.width * pair.height) / 1e6;
+
+export const isHeavy = (pair: FixturePair) =>
+	megapixels(pair) > HEAVY_MEGAPIXELS;
+
+const BY_ID = new Map<string, FixturePair>(
+	[...INTERPRET_FIXTURES, IDENTICAL_PAIR].map((pair) => [pair.id, pair]),
+);
+
+export const findPair = (id: string): FixturePair | undefined => BY_ID.get(id);
+
+/** Pairs bucketed by fixture directory, preserving the order above. */
+export function groupPairs(items: FixturePair[]): [string, FixturePair[]][] {
+	const groups: [string, FixturePair[]][] = [];
+	for (const pair of items) {
+		const last = groups[groups.length - 1];
+		if (last && last[0] === pair.group) {
+			last[1].push(pair);
+			continue;
+		}
+		groups.push([pair.group, [pair]]);
+	}
+	return groups;
+}

--- a/apps/website/components/interpret-summary.tsx
+++ b/apps/website/components/interpret-summary.tsx
@@ -8,12 +8,18 @@ export interface InterpretSummaryProps {
 	children?: ReactNode;
 }
 
+// Keyed on what `ChangeSeverity` actually serializes to. serde renames it
+// kebab-case, so the value on the wire is "low" / "medium" / "high" — a map
+// keyed on "Low" missed every time and fell through to the gray default.
 const severityColors: Record<string, string> = {
-	Low: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
-	Medium:
+	low: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+	medium:
 		"bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
-	High: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+	high: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
 };
+
+const titleCase = (value: string) =>
+	value.charAt(0).toUpperCase() + value.slice(1);
 
 export default function InterpretSummary({
 	severity,
@@ -27,7 +33,7 @@ export default function InterpretSummary({
 				<span
 					className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${severityColors[severity] ?? "bg-gray-100 text-gray-800"}`}
 				>
-					{severity}
+					{titleCase(severity)}
 				</span>
 				<span>{diffPercentage.toFixed(2)}% changed</span>
 			</div>

--- a/apps/website/components/interpret.worker.ts
+++ b/apps/website/components/interpret.worker.ts
@@ -1,0 +1,147 @@
+/// <reference lib="webworker" />
+
+// Fetching, decoding and interpreting all happen here so the ~236 MB RGBA
+// buffers a large fixture produces never cross to the main thread, and so the
+// several seconds of classification never block paint.
+
+import {
+	type InterpretResult,
+	initInterpret,
+	interpret,
+} from "@blazediff/interpret-wasm";
+
+export interface InterpretRequest {
+	a: string;
+	b: string;
+	width: number;
+	height: number;
+	/**
+	 * Absolute URL of the wasm module, supplied by the caller.
+	 *
+	 * The glue's own `new URL(..., import.meta.url)` default does not work
+	 * here: Turbopack rewrites it to a root-relative `/_next/static/media/...`,
+	 * and this worker runs from a blob: URL, which gives a root-relative path
+	 * nothing to resolve against. Taking the URL as input also keeps this
+	 * worker a pure function of its message, with no build-time coupling.
+	 */
+	wasmUrl: string;
+}
+
+export type InterpretPhase = "fetching" | "decoding" | "analyzing";
+
+export type InterpretResponse =
+	| { type: "phase"; phase: InterpretPhase }
+	| { type: "done"; result: InterpretResult }
+	| { type: "error"; message: string };
+
+/**
+ * Browsers cap canvas *area*, and iOS Safari's cap is roughly this. Past it the
+ * canvas fallback silently produces a blank or throws something opaque, so fail
+ * with a sentence the reader can act on instead.
+ */
+const CANVAS_AREA_LIMIT = 16.7e6;
+
+const post = (message: InterpretResponse) => self.postMessage(message);
+
+function mimeOf(url: string): string {
+	return url.endsWith(".jpg") || url.endsWith(".jpeg")
+		? "image/jpeg"
+		: "image/png";
+}
+
+/**
+ * `ImageDecoder` first: it has no canvas area cap, which is the only way the
+ * `page` and `4k-jpeg` fixtures decode at all. Chromium and Firefox have it;
+ * Safari falls through to the canvas path.
+ */
+async function decodeRgba(
+	bytes: ArrayBuffer,
+	type: string,
+): Promise<Uint8Array> {
+	if (
+		typeof ImageDecoder !== "undefined" &&
+		(await ImageDecoder.isTypeSupported(type))
+	) {
+		const decoder = new ImageDecoder({ data: bytes, type });
+		const { image } = await decoder.decode();
+		try {
+			const buffer = new Uint8Array(image.allocationSize({ format: "RGBA" }));
+			await image.copyTo(buffer, { format: "RGBA" });
+			return buffer;
+		} finally {
+			image.close();
+			decoder.close();
+		}
+	}
+
+	const bitmap = await createImageBitmap(new Blob([bytes], { type }));
+	try {
+		const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+		const context = canvas.getContext("2d");
+		if (!context) throw new Error("could not get a 2d canvas context");
+		context.drawImage(bitmap, 0, 0);
+		const { data } = context.getImageData(0, 0, bitmap.width, bitmap.height);
+		return new Uint8Array(data.buffer);
+	} finally {
+		bitmap.close();
+	}
+}
+
+/**
+ * Hand `initInterpret` a `Response` so it can still stream-compile, but check
+ * the status first: passing a failed response straight through means the CDN's
+ * error page reaches the wasm instantiator, which reports it as
+ * "expected magic word 00 61 73 6d" rather than as the 404 it is.
+ */
+async function fetchWasm(url: string): Promise<Response> {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`could not load the interpret wasm module (HTTP ${response.status} from ${url})`,
+		);
+	}
+	return response;
+}
+
+async function fetchBytes(url: string): Promise<ArrayBuffer> {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`could not fetch ${url} (HTTP ${response.status})`);
+	}
+	return response.arrayBuffer();
+}
+
+self.onmessage = async (event: MessageEvent<InterpretRequest>) => {
+	const { a, b, width, height, wasmUrl } = event.data;
+
+	try {
+		if (
+			typeof ImageDecoder === "undefined" &&
+			width * height > CANVAS_AREA_LIMIT
+		) {
+			throw new Error(
+				`Your browser cannot decode a ${width}×${height} image (canvas size limit). Try Chrome or Firefox, or pick a smaller pair.`,
+			);
+		}
+
+		post({ type: "phase", phase: "fetching" });
+		const [bytesA, bytesB] = await Promise.all([fetchBytes(a), fetchBytes(b)]);
+
+		post({ type: "phase", phase: "decoding" });
+		const [dataA, dataB] = await Promise.all([
+			decodeRgba(bytesA, mimeOf(a)),
+			decodeRgba(bytesB, mimeOf(b)),
+		]);
+
+		post({ type: "phase", phase: "analyzing" });
+		await initInterpret(await fetchWasm(wasmUrl));
+		const result = await interpret(dataA, dataB, width, height);
+
+		post({ type: "done", result });
+	} catch (error) {
+		post({
+			type: "error",
+			message: error instanceof Error ? error.message : String(error),
+		});
+	}
+};

--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -11,9 +11,27 @@ const apiSlugs = fs
 	.filter((entry) => entry.isDirectory())
 	.map((entry) => entry.name);
 
+// The interpret demo loads its wasm from jsDelivr rather than from the bundle:
+// wasm-bindgen's glue resolves the module with `new URL(..., import.meta.url)`,
+// which Turbopack rewrites to a root-relative `/_next/static/media/...`, and
+// the analysis worker runs from a blob: URL where that has nothing to resolve
+// against. Reading the version from the workspace manifest keeps the CDN URL
+// pinned to whatever this checkout ships, with no second place to update.
+const interpretWasmVersion = JSON.parse(
+	fs.readFileSync(
+		fileURLToPath(
+			new URL("../../packages/interpret-wasm/package.json", import.meta.url),
+		),
+		"utf8",
+	),
+).version;
+
 export default withNextra({
 	reactStrictMode: true,
 	devIndicators: false,
+	env: {
+		NEXT_PUBLIC_INTERPRET_WASM_VERSION: interpretWasmVersion,
+	},
 	async redirects() {
 		// Two route renames: the friendly docs (formerly /examples) now live at
 		// /docs, and the API reference (formerly /docs) moved to /apis. Keep

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -20,6 +20,7 @@
 		"@blazediff/core-native": "workspace:*",
 		"@blazediff/gmsd": "workspace:*",
 		"@blazediff/interpret-native": "workspace:*",
+		"@blazediff/interpret-wasm": "workspace:*",
 		"@blazediff/object": "workspace:*",
 		"@blazediff/react": "workspace:*",
 		"@blazediff/ssim": "workspace:*",

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -10,7 +10,8 @@
 - **Native (Rust)**: 4.4-4.9x faster than odiff on 4K images (5.7-6.7x from encoded buffers)
 - **WASM**: ~51% faster than pixelmatch, up to ~10x on 4K (browser, edge, any wasm host)
 - **Image Pixel-by-Pixel (JS)**: ~50% faster than pixelmatch (up to 88% on identical images)
-- **SSIM**: ~25% faster than ssim.js, ~70% faster with Hitchhiker's SSIM
+- **SSIM (JS)**: ~30% faster than ssim.js, ~75% faster with Hitchhiker's SSIM
+- **SSIM (Rust)**: ~15x faster again than the JS port (~4x for Hitchhiker's SSIM), from the same decoded buffers
 - **Object Diff**: ~55% faster than microdiff (up to 96% on identical arrays)
 
 ---
@@ -3314,18 +3315,18 @@ with human-readable summaries. It is not part of this crate: it lives in
 [`blazediff-interpret`](/apis/blazediff-interpret), which consumes what `diff`
 returns and ships its own `blazediff-interpret` binary.
 
-**Pipeline:** change mask -> morph close -> connected components -> per-region evidence extraction -> classify -> describe
+**Pipeline:** change mask -> morph close -> connected components -> noise census + fragment merge -> per-region evidence extraction -> classify -> shift pairing -> describe
 
-**Six-label decision tree:**
+**Six-label rule cascade:**
 
-| Type             | Signal                                                                  |
-| ---------------- | ----------------------------------------------------------------------- |
-| `RenderingNoise` | Tiny (&lt;=25px) or sparse + low color delta                             |
-| `Addition`       | Blends with background in img1, distinct in img2                        |
-| `Deletion`       | Distinct in img1, blends with background in img2                        |
-| `ColorChange`    | Edge structure preserved across both images + uniform color shift       |
-| `ContentChange`  | Fallback - structural change                                            |
-| `Shift`          | Post-hoc: matched Addition+Deletion pair with similar luminance         |
+| Type             | Signal                                                                     |
+| ---------------- | -------------------------------------------------------------------------- |
+| `RenderingNoise` | Tiny (&lt;=25px) or sparse + low color delta, without an add/delete signature |
+| `Addition`       | Blends with background in img1, distinct in img2                           |
+| `Deletion`       | Distinct in img1, blends with background in img2                           |
+| `ColorChange`    | Luminance structure preserved under a color shift, or a coherent chroma move (hue rotation, smooth delta field) over regenerated texture |
+| `ContentChange`  | Fallback - structure replaced, chroma scattered                            |
+| `Shift`          | Post-hoc: region pair whose before-crop and after-crop hold the same content, matched by patch correlation |
 
 ```sh
 blazediff-interpret a.png b.png
@@ -4872,9 +4873,12 @@ that were measured deterministically is answering a much easier question. See
 4. Fragments are assembled into regions: a **noise census** counts speck-sized
    fragments to measure how noisy the pair is, nearby bounding boxes are merged
    (an inpainted object shattered into patches, the words of one recolored text
-   run), and a noise floor that scales with the census drops the rest — so a
-   clean UI render keeps its smallest real regions while a recompressed photo
-   sheds hundreds of ringing fragments.
+   run) — but only when the box that would enclose them is mostly _touched_
+   below the diff threshold, so two distinct edits with untouched background
+   between them stay separate instead of collapsing into one region — and a
+   noise floor that scales with the census drops the rest, so a clean UI render
+   keeps its smallest real regions while a recompressed photo sheds hundreds of
+   ringing fragments.
 5. Evidence is extracted per region:
    - **Dual-image gradients and luminance correlation.** Edges in both images
      plus spatial correlation, to detect whether structure was preserved.
@@ -4892,7 +4896,8 @@ that were measured deterministically is answering a much easier question. See
    the content that appeared at another — by directly correlating the two image
    crops, scored best-first — and relabels both halves as a Shift.
 
-## Demo
+Pick a fixture pair. The analysis runs in your browser, in a Web Worker, on the
+same Rust classifier compiled to wasm — nothing here is precomputed.
 
 ## Usage
 

--- a/apps/website/utils/fixtures.ts
+++ b/apps/website/utils/fixtures.ts
@@ -1,0 +1,9 @@
+// The repo's committed fixtures, served straight off GitHub raw. `fixtures/`
+// is plain git (not LFS) and raw.githubusercontent.com sends
+// `access-control-allow-origin: *`, so these decode into a canvas untainted.
+
+export const RAW_FIXTURES =
+	"https://raw.githubusercontent.com/teimurjan/blazediff/refs/heads/main/fixtures";
+
+export const fixtureUrl = (group: string, file: string) =>
+	`${RAW_FIXTURES}/${group}/${file}`;

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,8 @@
 		"includes": [
 			"**/*.{js,ts,jsx,tsx,json}",
 			"!crates",
-			"!packages/core-wasm/wasm"
+			"!packages/core-wasm/wasm",
+			"!packages/interpret-wasm/wasm"
 		],
 		"ignoreUnknown": false
 	},

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -120,13 +120,17 @@ dependencies = [
  "blazediff-shared",
  "blazediff-ssim",
  "clap",
+ "console_error_panic_hook",
+ "js-sys",
  "napi",
  "napi-build",
  "napi-derive",
  "pyo3",
  "pythonize",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/blazediff-interpret/Cargo.toml
+++ b/crates/blazediff-interpret/Cargo.toml
@@ -15,18 +15,31 @@ include = ["src/**/*", "build.rs", "Cargo.toml", "README.md"]
 [features]
 # Exposes `test_helpers` to downstream test suites.
 testing = []
+# Decoding for the front-ends that take file paths. The classifier itself never
+# touches a codec — it is handed `Image`s — so this stays off the default build
+# and, crucially, off `wasm`: `blazediff-shared/codecs` is what drags in the
+# vendored C (libjpeg-turbo, libspng, miniz) that wasm32 cannot link.
+io = ["blazediff/io", "blazediff-shared/codecs"]
 # N-API bindings for `@blazediff/interpret-native`.
 napi = [
     "dep:napi",
     "dep:napi-derive",
     "dep:napi-build",
     "dep:serde_json",
-    "blazediff-shared/codecs",
+    "io",
 ]
 # PyO3 bindings for the `blazediff-interpret` PyPI wheel.
-python = ["dep:pyo3", "dep:pythonize", "blazediff-shared/codecs"]
+python = ["dep:pyo3", "dep:pythonize", "io"]
 # The `blazediff-interpret` CLI.
-cli = ["dep:clap", "dep:serde_json", "blazediff-shared/codecs"]
+cli = ["dep:clap", "dep:serde_json", "io"]
+# wasm-bindgen bindings for `@blazediff/interpret-wasm`. Buffers-only, so no
+# codecs: the caller pre-decodes to RGBA8 in the host.
+wasm = [
+    "dep:wasm-bindgen",
+    "dep:js-sys",
+    "dep:serde-wasm-bindgen",
+    "dep:console_error_panic_hook",
+]
 
 [lib]
 name = "blazediff_interpret"
@@ -44,7 +57,7 @@ required-features = ["cli"]
 # than either of them depending on it. `version` is required to publish to
 # crates.io; kept in lockstep by scripts/release/sync-cargo-version.js.
 blazediff-shared = { path = "../blazediff-shared", version = "6.0.0", default-features = false }
-blazediff = { path = "../blazediff", version = "6.0.1", default-features = false, features = ["io"] }
+blazediff = { path = "../blazediff", version = "6.0.1", default-features = false }
 blazediff-ssim = { path = "../blazediff-ssim", version = "6.1.0" }
 serde = { version = "1", features = ["derive"] }
 napi = { version = "2", features = ["napi4", "serde-json"], optional = true }
@@ -58,6 +71,14 @@ clap = { version = "4", features = ["derive"], optional = true }
 # `InterpretResult` already derives Serialize, so the front-ends hand it across
 # as a plain object rather than restating ten `#[napi(object)]` structs.
 serde_json = { version = "1", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# wasm-bindgen pinned to match the wasm-bindgen-cli version used in
+# crates/scripts/build-wasm.sh. Bumping requires bumping both in lockstep.
+wasm-bindgen = { version = "=0.2.100", optional = true }
+js-sys = { version = "0.3", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
+console_error_panic_hook = { version = "0.1", optional = true }
 
 [build-dependencies]
 napi-build = { version = "2", optional = true }

--- a/crates/blazediff-interpret/scripts/build-wasm.sh
+++ b/crates/blazediff-interpret/scripts/build-wasm.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the wasm32 artifact (+ wasm-bindgen JS glue) for
+# @blazediff/interpret-wasm. The build itself lives in
+# crates/scripts/build-wasm.sh, shared with blazediff; this only names the
+# artifact.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRATE_DIR="$(dirname "$SCRIPT_DIR")"
+
+export CRATE_DIR
+export WASM_CRATE="blazediff-interpret"
+export WASM_LIB="blazediff_interpret"
+export WASM_OUT_NAME="blazediff_interpret"
+export WASM_PKG_DIR="interpret-wasm"
+
+exec "$CRATE_DIR/../scripts/build-wasm.sh" "$@"

--- a/crates/blazediff-interpret/src/lib.rs
+++ b/crates/blazediff-interpret/src/lib.rs
@@ -32,6 +32,8 @@ mod shape;
 mod shifts;
 mod spatial;
 mod summary;
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+mod wasm;
 // Small image constructors shared by this crate's tests and by `blazediff`'s
 // end-to-end interpret tests, which live there because they need `diff`.
 #[cfg(any(test, feature = "testing"))]

--- a/crates/blazediff-interpret/src/region/label_extract.rs
+++ b/crates/blazediff-interpret/src/region/label_extract.rs
@@ -1,18 +1,26 @@
 use super::super::types::BoundingBox;
 /// Extract labeled regions from a watershed label map into ComponentInfo structs.
 use super::ComponentInfo;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Convert a label map + original mask into ComponentInfo bounding boxes and pixel counts.
 /// Only counts pixels where `original_mask[i]` is true (not morphologically added pixels).
 /// Results sorted by pixel count descending.
+///
+/// Keyed by a `BTreeMap`, not a `HashMap`, because this map is *iterated* and
+/// the order reaches the caller. `HashMap`'s `RandomState` is seeded per
+/// process, so two components with equal `pixel_count` — which the stable sort
+/// below leaves in insertion order — came out in a different order on every
+/// run, and with them the region list and the summary's position list. Labels
+/// are assigned in raster-scan order, so ordering by label makes ties resolve
+/// top-left-first and keeps the whole pipeline deterministic, as documented.
 pub fn extract_labeled_regions(
     labels: &[i32],
     original_mask: &[bool],
     width: u32,
 ) -> Vec<ComponentInfo> {
     let w = width as usize;
-    let mut regions: HashMap<i32, ComponentInfo> = HashMap::new();
+    let mut regions: BTreeMap<i32, ComponentInfo> = BTreeMap::new();
 
     for (i, (&label, &in_mask)) in labels.iter().zip(original_mask.iter()).enumerate() {
         if label <= 0 || !in_mask {
@@ -108,6 +116,24 @@ mod tests {
         assert_eq!(regions[0].pixel_count, 3);
         assert_eq!(regions[1].pixel_count, 2);
         assert_eq!(regions[2].pixel_count, 1);
+    }
+
+    #[test]
+    fn equal_pixel_counts_keep_raster_order() {
+        // Two components of exactly the same size. Under a HashMap the pair
+        // came back in a per-process random order, which leaked all the way
+        // out to `InterpretResult::regions` and the summary text.
+        // 5x1: label=[1, 1, 0, 2, 2]
+        let labels = vec![1, 1, 0, 2, 2];
+        let mask = vec![true, true, false, true, true];
+
+        let regions = extract_labeled_regions(&labels, &mask, 5);
+
+        assert_eq!(regions.len(), 2);
+        assert_eq!(regions[0].pixel_count, regions[1].pixel_count);
+        // The tie must resolve to the component encountered first.
+        assert_eq!(regions[0].bbox.x, 0);
+        assert_eq!(regions[1].bbox.x, 3);
     }
 
     #[test]

--- a/crates/blazediff-interpret/src/wasm.rs
+++ b/crates/blazediff-interpret/src/wasm.rs
@@ -1,0 +1,108 @@
+//! Browser-facing wasm-bindgen entry points.
+//!
+//! Buffers-only API: callers pre-decode images to RGBA8 bytes (via `<canvas>`,
+//! `createImageBitmap`, `ImageDecoder`, etc.) and pass `Uint8Array`s in. No
+//! PNG/JPEG decoders are bundled into the wasm artifact — that is what the
+//! `io` feature is for, and it stays off here.
+
+use crate::interpret_diff;
+use blazediff::DiffOptions;
+use blazediff_shared::Image;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn _start() {
+    console_error_panic_hook::set_once();
+}
+
+/// Wrap the caller's RGBA bytes without copying them.
+///
+/// The parameter is taken by value for the same reason as in `blazediff`'s
+/// `wasm.rs`: wasm-bindgen has already copied the JS typed array into a
+/// wasm-side allocation, and an owned `Vec<u8>` parameter takes ownership of
+/// exactly that allocation. Borrowing it as `&[u8]` and calling `to_vec()`
+/// would copy every input buffer a second time.
+fn image_from_vec(rgba: Vec<u8>, width: u32, height: u32, label: &str) -> Result<Image, JsError> {
+    let expected = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|v| v.checked_mul(4))
+        .ok_or_else(|| JsError::new("width*height overflow"))?;
+    if rgba.len() != expected {
+        return Err(JsError::new(&format!(
+            "{}: expected {} bytes (width*height*4), got {}",
+            label,
+            expected,
+            rgba.len()
+        )));
+    }
+    Ok(Image {
+        data: rgba,
+        width,
+        height,
+    })
+}
+
+fn copy_output(
+    target: Option<js_sys::Uint8Array>,
+    output: Option<&Image>,
+    has_diff: bool,
+) -> Result<(), JsError> {
+    let (Some(target), Some(output)) = (target, output) else {
+        return Ok(());
+    };
+    if target.length() as usize != output.data.len() {
+        return Err(JsError::new(&format!(
+            "out_diff: expected {} bytes, got {}",
+            output.data.len(),
+            target.length()
+        )));
+    }
+    if has_diff {
+        target.copy_from(&output.data);
+    }
+    Ok(())
+}
+
+/// Interpret the pixel diff between two RGBA buffers.
+///
+/// Returns the `InterpretResult` as a plain JS object — the same shape
+/// `@blazediff/interpret-native` returns, because both serialize the one
+/// `Serialize` derive on the struct.
+///
+/// If `out_diff` is provided, the diff visualization is written into it
+/// in-place (must be width*height*4 bytes). Pass `null`/`undefined` to skip it;
+/// the diff still needs a scratch buffer internally, but nothing is copied back.
+#[wasm_bindgen(js_name = interpretRgba)]
+pub fn interpret_rgba(
+    rgba_a: Vec<u8>,
+    rgba_b: Vec<u8>,
+    width: u32,
+    height: u32,
+    threshold: f64,
+    antialiasing: bool,
+    out_diff: Option<js_sys::Uint8Array>,
+) -> Result<JsValue, JsError> {
+    let img1 = image_from_vec(rgba_a, width, height, "rgba_a")?;
+    let img2 = image_from_vec(rgba_b, width, height, "rgba_b")?;
+
+    let defaults = DiffOptions::default();
+    let opts = DiffOptions {
+        threshold,
+        // Mirrors the N-API surface, which calls it `antialiasing` where the
+        // core calls the inverse `include_aa`. Keeping the two front-ends
+        // identical is what lets the same options object drive either.
+        include_aa: !antialiasing,
+        ..defaults
+    };
+
+    let mut output_image = out_diff.as_ref().map(|_| Image::new_uninit(width, height));
+
+    let result = interpret_diff(&img1, &img2, output_image.as_mut(), &opts)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+
+    // On identical input the diff intentionally leaves the output buffer
+    // unwritten — see `Image::new_uninit`.
+    copy_output(out_diff, output_image.as_ref(), result.diff_count > 0)?;
+
+    serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+}

--- a/crates/blazediff/scripts/build-wasm.sh
+++ b/crates/blazediff/scripts/build-wasm.sh
@@ -2,64 +2,16 @@
 set -euo pipefail
 
 # Build the wasm32 artifact (+ wasm-bindgen JS glue) for @blazediff/core-wasm.
-# Single target, no cross-compilation matrix — wasm is wasm.
+# The build itself lives in crates/scripts/build-wasm.sh, shared with
+# blazediff-interpret; this only names the artifact.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CRATE_DIR="$(dirname "$SCRIPT_DIR")"
-# shellcheck source=../../scripts/_targets.sh
-source "$CRATE_DIR/../scripts/_targets.sh"
 
-# Keep wasm-bindgen-cli pinned in lockstep with the wasm-bindgen crate dep
-# in Cargo.toml. Mismatched versions error out at the post-process step.
-WASM_BINDGEN_VERSION="${WASM_BINDGEN_VERSION:-0.2.100}"
+export CRATE_DIR
+export WASM_CRATE="blazediff"
+export WASM_LIB="blazediff"
+export WASM_OUT_NAME="blazediff"
+export WASM_PKG_DIR="core-wasm"
 
-OUT_DIR="$PACKAGES_DIR/core-wasm/wasm"
-WASM_FILE="$TARGET_DIR/wasm32-unknown-unknown/release/blazediff.wasm"
-
-echo "Building blazediff for wasm32-unknown-unknown..."
-rustup target add wasm32-unknown-unknown 2>/dev/null || true
-
-cd "$PROJECT_DIR"
-
-RUSTFLAGS="-C target-feature=+simd128,+bulk-memory" \
-    cargo build --release \
-        --target wasm32-unknown-unknown \
-        --no-default-features --features wasm \
-        --manifest-path "$WORKSPACE_DIR/Cargo.toml" \
-        -p blazediff
-
-if [[ ! -f "$WASM_FILE" ]]; then
-    echo "Error: wasm artifact not found at $WASM_FILE"
-    exit 1
-fi
-
-echo "Raw wasm size: $(ls -lh "$WASM_FILE" | awk '{print $5}')"
-
-if ! command -v wasm-bindgen &> /dev/null; then
-    echo "Installing wasm-bindgen-cli $WASM_BINDGEN_VERSION..."
-    cargo install -f wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION"
-fi
-
-mkdir -p "$OUT_DIR"
-echo "Running wasm-bindgen..."
-wasm-bindgen "$WASM_FILE" \
-    --out-dir "$OUT_DIR" \
-    --out-name blazediff \
-    --target web
-
-if command -v wasm-opt &> /dev/null; then
-    echo "Running wasm-opt -O3..."
-    wasm-opt -O3 \
-        --enable-simd \
-        --enable-bulk-memory \
-        --enable-mutable-globals \
-        --enable-nontrapping-float-to-int \
-        --enable-sign-ext \
-        --enable-reference-types \
-        --enable-multivalue \
-        -o "$OUT_DIR/blazediff_bg.wasm" "$OUT_DIR/blazediff_bg.wasm"
-fi
-
-echo ""
-echo "Done. Output:"
-ls -lh "$OUT_DIR"
+exec "$CRATE_DIR/../scripts/build-wasm.sh" "$@"

--- a/crates/scripts/build-wasm.sh
+++ b/crates/scripts/build-wasm.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a wasm32 artifact (+ wasm-bindgen JS glue) for one of the wasm packages.
+# Single target, no cross-compilation matrix — wasm is wasm.
+#
+# Callers set CRATE_DIR and the WASM_* variables naming the artifact; each crate
+# that ships a wasm package has a shim in its own scripts/ that does exactly
+# that, the same way build-napi.sh is driven. Defaults reproduce the original
+# core build so a bare invocation still produces @blazediff/core-wasm.
+
+: "${CRATE_DIR:?CRATE_DIR must be set before running build-wasm.sh}"
+
+# Cargo package to build.
+WASM_CRATE="${WASM_CRATE:-blazediff}"
+# `[lib] name`, i.e. what cargo writes into target/.../release/<lib>.wasm.
+WASM_LIB="${WASM_LIB:-blazediff}"
+# wasm-bindgen --out-name; decides the generated <name>.js / <name>_bg.wasm.
+WASM_OUT_NAME="${WASM_OUT_NAME:-blazediff}"
+# Destination package under packages/.
+WASM_PKG_DIR="${WASM_PKG_DIR:-core-wasm}"
+
+# shellcheck source=./_targets.sh
+source "$CRATE_DIR/../scripts/_targets.sh"
+
+# Keep wasm-bindgen-cli pinned in lockstep with the wasm-bindgen crate dep
+# in Cargo.toml. Mismatched versions error out at the post-process step.
+WASM_BINDGEN_VERSION="${WASM_BINDGEN_VERSION:-0.2.100}"
+
+OUT_DIR="$PACKAGES_DIR/$WASM_PKG_DIR/wasm"
+WASM_FILE="$TARGET_DIR/wasm32-unknown-unknown/release/$WASM_LIB.wasm"
+
+echo "Building $WASM_CRATE for wasm32-unknown-unknown..."
+rustup target add wasm32-unknown-unknown 2>/dev/null || true
+
+cd "$PROJECT_DIR"
+
+RUSTFLAGS="-C target-feature=+simd128,+bulk-memory" \
+    cargo build --release \
+        --target wasm32-unknown-unknown \
+        --no-default-features --features wasm \
+        --manifest-path "$WORKSPACE_DIR/Cargo.toml" \
+        -p "$WASM_CRATE"
+
+if [[ ! -f "$WASM_FILE" ]]; then
+    echo "Error: wasm artifact not found at $WASM_FILE"
+    exit 1
+fi
+
+echo "Raw wasm size: $(ls -lh "$WASM_FILE" | awk '{print $5}')"
+
+if ! command -v wasm-bindgen &> /dev/null; then
+    echo "Installing wasm-bindgen-cli $WASM_BINDGEN_VERSION..."
+    cargo install -f wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION"
+fi
+
+mkdir -p "$OUT_DIR"
+echo "Running wasm-bindgen..."
+wasm-bindgen "$WASM_FILE" \
+    --out-dir "$OUT_DIR" \
+    --out-name "$WASM_OUT_NAME" \
+    --target web
+
+if command -v wasm-opt &> /dev/null; then
+    echo "Running wasm-opt -O3..."
+    wasm-opt -O3 \
+        --enable-simd \
+        --enable-bulk-memory \
+        --enable-mutable-globals \
+        --enable-nontrapping-float-to-int \
+        --enable-sign-ext \
+        --enable-reference-types \
+        --enable-multivalue \
+        -o "$OUT_DIR/${WASM_OUT_NAME}_bg.wasm" "$OUT_DIR/${WASM_OUT_NAME}_bg.wasm"
+fi
+
+echo ""
+echo "Done. Output:"
+ls -lh "$OUT_DIR"

--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,7 @@
 		"./packages/core-native/core-native",
 		"./packages/core-wasm",
 		"./packages/interpret-native/interpret-native",
+		"./packages/interpret-wasm",
 		"./packages/ssim-native/ssim-native",
 		"./packages/matcher",
 		"./packages/cli"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"build:rust:ssim": "cd crates/blazediff-ssim && ./scripts/build-napi.sh --all",
 		"build:rust:interpret": "cd crates/blazediff-interpret && ./scripts/build-napi.sh --all",
 		"build:wasm": "cd crates/blazediff && ./scripts/build-wasm.sh",
+		"build:wasm:interpret": "cd crates/blazediff-interpret && ./scripts/build-wasm.sh",
 		"build:python": "cd crates/blazediff && ./scripts/build-maturin.sh",
 		"build:python:all": "cd crates/blazediff && ./scripts/build-maturin.sh --all",
 		"build:python:ssim": "cd crates/blazediff-ssim && ./scripts/build-maturin.sh",

--- a/packages/interpret-wasm/README.md
+++ b/packages/interpret-wasm/README.md
@@ -1,0 +1,156 @@
+# @blazediff/interpret-wasm
+
+<div align="center">
+
+[![npm bundle size](https://img.shields.io/npm/unpacked-size/%40blazediff%2Finterpret-wasm?style=for-the-badge)](https://www.npmjs.com/package/@blazediff/interpret-wasm)
+[![NPM Downloads](https://img.shields.io/npm/dy/%40blazediff%2Finterpret-wasm?style=for-the-badge)](https://www.npmjs.com/package/@blazediff/interpret-wasm)
+[![Crates.io](https://img.shields.io/crates/v/blazediff-interpret.svg?style=for-the-badge)](https://crates.io/crates/blazediff-interpret)
+
+</div>
+
+WebAssembly build of the BlazeDiff interpret classifier for browsers, edge runtimes, and any wasm host. Same deterministic pipeline as [`@blazediff/interpret-native`](https://www.npmjs.com/package/@blazediff/interpret-native), compiled to `wasm32` with `v128` SIMD (`+simd128`) — it takes a raw pixel diff and tells you *what* changed, where, and how much, as labelled regions rather than one number.
+
+No model, no weights, no network call.
+
+**Features:**
+- Same Rust classifier as `@blazediff/interpret-native`, and the result shape is identical
+- Six change labels: `addition`, `deletion`, `shift`, `color-change`, `content-change`, `rendering-noise`
+- Buffers-only API: caller decodes images, hands in `Uint8Array`. No PNG/JPEG codecs bundled
+- ~146 KB optimized wasm + ~12 KB JS glue. No native binaries, no postinstall, no platform packages
+- Runs anywhere wasm runs: browsers, Node 18+, Cloudflare Workers, Deno, Bun
+
+## Installation
+
+```bash
+npm install @blazediff/interpret-wasm
+```
+
+## Loading the wasm module
+
+Identical to [`@blazediff/core-wasm`](https://www.npmjs.com/package/@blazediff/core-wasm) — the wasm-bindgen `--target web` glue fetches the sibling `.wasm` via `import.meta.url` automatically:
+
+```typescript
+import { initInterpret } from '@blazediff/interpret-wasm';
+await initInterpret();
+```
+
+Pass a `URL`, `Response`, or raw bytes to load it from anywhere else:
+
+```typescript
+// Bundlers (Vite, Webpack 5+, esbuild) rewrite this at build time:
+await initInterpret(
+  new URL('@blazediff/interpret-wasm/wasm/blazediff_interpret_bg.wasm', import.meta.url),
+);
+
+// Node from the local filesystem:
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+await initInterpret(
+  readFileSync(
+    createRequire(import.meta.url).resolve(
+      '@blazediff/interpret-wasm/wasm/blazediff_interpret_bg.wasm',
+    ),
+  ),
+);
+```
+
+`initInterpret()` is memoized — call it as often as you like, the module is instantiated once.
+
+## Usage
+
+Both buffers must be `width * height * 4` bytes in RGBA8 order.
+
+```typescript
+import { initInterpret, interpret } from '@blazediff/interpret-wasm';
+
+await initInterpret();
+
+const result = await interpret(rgbaA, rgbaB, width, height);
+
+console.log(result.summary);
+for (const region of result.regions) {
+  console.log(`${region.position}: ${region.changeType} (${region.percentage.toFixed(2)}%)`);
+}
+```
+
+Pass a fifth argument to keep the diff visualization. It must be `width * height * 4` bytes and is written in place:
+
+```typescript
+const output = new Uint8Array(width * height * 4);
+await interpret(rgbaA, rgbaB, width, height, output);
+```
+
+Options go last:
+
+```typescript
+await interpret(rgbaA, rgbaB, width, height, undefined, {
+  threshold: 0.1,      // color difference threshold (0-1). Default: 0.1
+  antialiasing: false, // exclude anti-aliased pixels. Default: false
+});
+```
+
+## Decoding images in the browser
+
+This package bundles no codecs, so decode first. `ImageDecoder` (WebCodecs) has no canvas size cap and is the better path for large images:
+
+```typescript
+async function toRgba(bytes: ArrayBuffer, type: string) {
+  if (typeof ImageDecoder !== 'undefined' && (await ImageDecoder.isTypeSupported(type))) {
+    const decoder = new ImageDecoder({ data: bytes, type });
+    const { image } = await decoder.decode();
+    const buffer = new Uint8Array(image.allocationSize({ format: 'RGBA' }));
+    await image.copyTo(buffer, { format: 'RGBA' });
+    const size = { width: image.displayWidth, height: image.displayHeight };
+    image.close();
+    decoder.close();
+    return { ...size, data: buffer };
+  }
+
+  // Fallback. Note browsers cap canvas area (iOS Safari at ~16.7 MP).
+  const bitmap = await createImageBitmap(new Blob([bytes], { type }));
+  const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(bitmap, 0, 0);
+  const { data } = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+  bitmap.close();
+  return { width: canvas.width, height: canvas.height, data: new Uint8Array(data.buffer) };
+}
+```
+
+Large pairs are worth running in a Web Worker: a 59 MP pair allocates roughly a gigabyte inside wasm, and wasm linear memory never shrinks — terminating the worker is the only way to give it back.
+
+## Result shape
+
+```typescript
+interface InterpretResult {
+  summary: string;
+  diffCount: number;       // actually-changed pixels
+  totalRegions: number;
+  regions: ChangeRegion[];
+  severity: string;        // "low" | "medium" | "high"
+  diffPercentage: number;
+  width: number;
+  height: number;
+}
+```
+
+Each `ChangeRegion` carries a `bbox`, `changeType`, `position`, `shape`, `percentage`, `pixelCount`, `confidence`, and the per-region evidence the classifier used (`chroma`, `colorDelta`, `gradient`, `shapeStats`, `signals`).
+
+## Change types
+
+| Type | Meaning |
+|---|---|
+| `addition` | Content appeared. Blends with the background in the before image, distinct in the after image. |
+| `deletion` | Content was removed. Distinct before, blends with the background after. |
+| `shift` | Content moved. Two regions whose before-crop and after-crop hold the same content. |
+| `color-change` | A recolor. Luminance structure preserved under a color shift, or chroma moved coherently. |
+| `content-change` | A structural change. Structure replaced and the chroma scattered rather than rotated. |
+| `rendering-noise` | Sub-pixel artifacts. Filtered out of the output. |
+
+## Documentation
+
+Full write-up of the pipeline and accuracy numbers: [blazediff.dev/docs/difference-analysis](https://blazediff.dev/docs/difference-analysis).
+
+## License
+
+MIT

--- a/packages/interpret-wasm/deno.json
+++ b/packages/interpret-wasm/deno.json
@@ -1,0 +1,19 @@
+{
+	"name": "@blazediff/interpret-wasm",
+	"version": "6.3.0",
+	"exports": "./src/index.ts",
+	"publish": {
+		"include": [
+			"src/**/*.ts",
+			"wasm/blazediff_interpret.js",
+			"wasm/blazediff_interpret.d.ts",
+			"wasm/blazediff_interpret_bg.wasm",
+			"wasm/blazediff_interpret_bg.wasm.d.ts",
+			"README.md"
+		],
+		"exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.deno.test.ts"]
+	},
+	"test": {
+		"include": ["src/**/*.deno.test.ts"]
+	}
+}

--- a/packages/interpret-wasm/package.json
+++ b/packages/interpret-wasm/package.json
@@ -1,0 +1,58 @@
+{
+	"name": "@blazediff/interpret-wasm",
+	"version": "6.3.0",
+	"description": "WebAssembly build of blazediff-interpret for browsers, edge runtimes, and any wasm host. Same classifier as @blazediff/interpret-native.",
+	"private": false,
+	"publishConfig": {
+		"access": "public"
+	},
+	"type": "module",
+	"module": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		},
+		"./wasm/blazediff_interpret_bg.wasm": "./wasm/blazediff_interpret_bg.wasm"
+	},
+	"files": [
+		"dist",
+		"wasm"
+	],
+	"scripts": {
+		"typecheck": "tsc --noEmit",
+		"build": "tsup",
+		"build:wasm": "cd ../../crates/blazediff-interpret && ./scripts/build-wasm.sh",
+		"clean": "rm -rf dist",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"keywords": [
+		"image",
+		"comparison",
+		"diff",
+		"interpret",
+		"classification",
+		"visual-testing",
+		"visual-regression",
+		"screenshot",
+		"wasm",
+		"webassembly",
+		"browser",
+		"simd"
+	],
+	"author": "Teimur Gasanov <me@teimurjan.dev> (https://github.com/teimurjan)",
+	"repository": "https://github.com/teimurjan/blazediff",
+	"homepage": "https://blazediff.dev",
+	"license": "MIT",
+	"devDependencies": {
+		"@blazediff/interpret-native": "workspace:*",
+		"@types/node": "^24.3.0",
+		"@types/pngjs": "^6.0.5",
+		"pngjs": "^7.0.0",
+		"tsup": "8.5.0",
+		"typescript": "5.9.2",
+		"vitest": "^3.2.4"
+	}
+}

--- a/packages/interpret-wasm/src/index.test.ts
+++ b/packages/interpret-wasm/src/index.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { interpret as nativeInterpret } from "@blazediff/interpret-native";
+import { PNG } from "pngjs";
+import { beforeAll, describe, expect, it } from "vitest";
+import { initInterpret, interpret } from "./index";
+
+const FIXTURES_PATH = join(
+	fileURLToPath(new URL(".", import.meta.url)),
+	"../../../fixtures",
+);
+
+const WASM_PATH = join(
+	fileURLToPath(new URL(".", import.meta.url)),
+	"../wasm/blazediff_interpret_bg.wasm",
+);
+
+function loadPNG(rel: string): {
+	data: Uint8Array;
+	width: number;
+	height: number;
+} {
+	const png = PNG.sync.read(readFileSync(join(FIXTURES_PATH, rel)));
+	return {
+		data: new Uint8Array(png.data),
+		width: png.width,
+		height: png.height,
+	};
+}
+
+beforeAll(async () => {
+	// Node has no fetch-from-module-URL for the sibling .wasm, so hand the
+	// bytes over directly.
+	await initInterpret(readFileSync(WASM_PATH));
+});
+
+describe("interpret", () => {
+	// The whole point of the package: the browser build must agree with the
+	// N-API build, because they are the same Rust classifier.
+	const pairs = [
+		["blazediff/1a.png", "blazediff/1b.png"],
+		["blazediff/2a.png", "blazediff/2b.png"],
+		["blazediff/3a.png", "blazediff/3b.png"],
+		["blazediff/4a.png", "blazediff/4b.png"],
+		["pixelmatch/1a.png", "pixelmatch/1b.png"],
+		["alpha/1a.png", "alpha/1b.png"],
+	];
+
+	it.each(pairs)("matches interpret-native on %s", async (relA, relB) => {
+		const a = loadPNG(relA);
+		const b = loadPNG(relB);
+
+		const actual = await interpret(a.data, b.data, a.width, a.height);
+		const expected = await nativeInterpret(
+			join(FIXTURES_PATH, relA),
+			join(FIXTURES_PATH, relB),
+		);
+
+		expect(actual.summary).toBe(expected.summary);
+		expect(actual.severity).toBe(expected.severity);
+		expect(actual.diffCount).toBe(expected.diffCount);
+		expect(actual.totalRegions).toBe(expected.totalRegions);
+		expect(actual.width).toBe(expected.width);
+		expect(actual.height).toBe(expected.height);
+		expect(actual.diffPercentage).toBeCloseTo(expected.diffPercentage, 10);
+
+		expect(
+			actual.regions.map((r) => [r.bbox, r.changeType, r.position]),
+		).toEqual(expected.regions.map((r) => [r.bbox, r.changeType, r.position]));
+	});
+
+	it("reports no regions for an identical pair", async () => {
+		const a = loadPNG("blazediff/3a.png");
+
+		const result = await interpret(a.data, a.data, a.width, a.height);
+
+		expect(result.totalRegions).toBe(0);
+		expect(result.regions).toEqual([]);
+		expect(result.diffCount).toBe(0);
+	});
+
+	it("writes the visualization into a provided output buffer", async () => {
+		const a = loadPNG("blazediff/1a.png");
+		const b = loadPNG("blazediff/1b.png");
+		const output = new Uint8Array(a.width * a.height * 4);
+
+		const result = await interpret(a.data, b.data, a.width, a.height, output);
+
+		expect(result.diffCount).toBeGreaterThan(0);
+		expect(output.some((byte) => byte !== 0)).toBe(true);
+	});
+
+	it("rejects a buffer whose length is not width*height*4", async () => {
+		await expect(
+			interpret(new Uint8Array(4), new Uint8Array(4), 2, 2),
+		).rejects.toThrow(/expected 16 bytes/);
+	});
+
+	it("rejects an output buffer of the wrong length", async () => {
+		const a = loadPNG("alpha/1a.png");
+		const b = loadPNG("alpha/1b.png");
+
+		await expect(
+			interpret(a.data, b.data, a.width, a.height, new Uint8Array(8)),
+		).rejects.toThrow(/out_diff/);
+	});
+});

--- a/packages/interpret-wasm/src/index.ts
+++ b/packages/interpret-wasm/src/index.ts
@@ -1,0 +1,185 @@
+import init, {
+	interpretRgba as wasmInterpretRgba,
+} from "../wasm/blazediff_interpret.js";
+
+// Generated bindings are updated in version bump PRs, so keep the source-side
+// ABI explicit while this wrapper targets the next generated artifact.
+type WasmInterpretRgba = (
+	rgbaA: Uint8Array,
+	rgbaB: Uint8Array,
+	width: number,
+	height: number,
+	threshold: number,
+	antialiasing: boolean,
+	outDiff: Uint8Array | undefined,
+) => unknown;
+
+export interface BoundingBox {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export interface ShapeStats {
+	fillRatio: number;
+	borderRatio: number;
+	innerFillRatio: number;
+	centerDensity: number;
+	rowOccupancy: number;
+	colOccupancy: number;
+}
+
+export interface ColorDeltaStats {
+	meanDelta: number;
+	maxDelta: number;
+	deltaStddev: number;
+}
+
+export interface GradientStats {
+	edgeScore: number;
+	edgeScoreImg2: number;
+	edgeCorrelation: number;
+}
+
+export interface ChromaStats {
+	/** Mean |ΔY| (luminance delta magnitude), normalized to 255. */
+	meanAbsDy: number;
+	/** Signed mean ΔY. */
+	meanDy: number;
+	/** Mean |ΔI|. */
+	meanAbsDi: number;
+	/** Mean |ΔQ|. */
+	meanAbsDq: number;
+	/** Mean chroma-delta magnitude √(ΔI²+ΔQ²). */
+	meanAbsDc: number;
+	/** Cosine between the chroma vectors; near 1 = same hues, negative = hue rotation. */
+	chromaCos: number;
+	/** Mean chroma magnitude (saturation) in the first image. */
+	sat1: number;
+	/** Mean chroma magnitude in the second image. */
+	sat2: number;
+	/** Roughness of the chroma-delta field; low = smooth recolor, high = patchy replacement. */
+	chromaRough: number;
+}
+
+export interface ClassificationSignals {
+	blendsWithBgInImg1: boolean;
+	blendsWithBgInImg2: boolean;
+	lowColorDelta: boolean;
+	lowEdgeChange: boolean;
+	denseFill: boolean;
+	sparseFill: boolean;
+	tinyRegion: boolean;
+	edgesCorrelated: boolean;
+	/** Luminance NCC over the changed pixels; high = structure preserved. */
+	luminanceNcc: number;
+	/** Signed img2-minus-img1 edge density; positive = structure gained. */
+	structureAsymmetry: number;
+	/** Normalized RGB distance of changed pixels from local background in the first image. */
+	bgDistanceImg1: number;
+	/** Same measurement against the second image. */
+	bgDistanceImg2: number;
+	confidence: number;
+}
+
+export interface ChangeRegion {
+	bbox: BoundingBox;
+	/** Actually-changed pixels inside the region, never map windows. */
+	pixelCount: number;
+	percentage: number;
+	position: string;
+	shape: string;
+	shapeStats: ShapeStats;
+	changeType: string;
+	signals: ClassificationSignals;
+	confidence: number;
+	colorDelta: ColorDeltaStats;
+	gradient: GradientStats;
+	chroma: ChromaStats;
+}
+
+export interface InterpretResult {
+	summary: string;
+	/** Actually-changed pixels, on every source. */
+	diffCount: number;
+	totalRegions: number;
+	regions: ChangeRegion[];
+	severity: string;
+	diffPercentage: number;
+	width: number;
+	height: number;
+}
+
+export interface InterpretOptions {
+	/** Color difference threshold (0-1). Lower = stricter. Default: 0.1 */
+	threshold?: number;
+	/** Exclude anti-aliased pixels. Default: false */
+	antialiasing?: boolean;
+}
+
+export type WasmInput =
+	| RequestInfo
+	| URL
+	| Response
+	| BufferSource
+	| WebAssembly.Module;
+
+let initPromise: Promise<unknown> | undefined;
+
+/**
+ * Initialize the wasm module. Safe to call multiple times - subsequent calls
+ * return the same promise. By default fetches the bundled
+ * `blazediff_interpret_bg.wasm` via the module's import path. Pass a custom
+ * `URL`, `Response`, or bytes to load the wasm from a different location (CDN,
+ * custom asset pipeline, etc.).
+ */
+export function initInterpret(input?: WasmInput): Promise<void> {
+	if (!initPromise) {
+		const arg =
+			input === undefined ? undefined : ({ module_or_path: input } as never);
+		initPromise = init(arg).then(() => undefined);
+	}
+	return initPromise as Promise<void>;
+}
+
+/**
+ * Describe what changed between two RGBA pixel buffers.
+ *
+ * Both buffers must be `width * height * 4` bytes in RGBA8 order. Decode
+ * PNG/JPEG with `createImageBitmap` + `OffscreenCanvas.getImageData()` (or the
+ * `ImageDecoder` API) and pass the resulting `Uint8Array` here.
+ *
+ * Returns the same shape as `@blazediff/interpret-native`: a `summary` string,
+ * a `regions[]` array and an overall `severity`.
+ *
+ * If `output` is provided it must be `width * height * 4` bytes long and the
+ * diff visualization is written into it in place.
+ */
+export function interpret(
+	a: Uint8Array,
+	b: Uint8Array,
+	width: number,
+	height: number,
+	output?: Uint8Array,
+	options?: InterpretOptions,
+): Promise<InterpretResult>;
+export async function interpret(
+	a: Uint8Array,
+	b: Uint8Array,
+	width: number,
+	height: number,
+	output?: Uint8Array,
+	options: InterpretOptions = {},
+): Promise<InterpretResult> {
+	await initInterpret();
+	return (wasmInterpretRgba as unknown as WasmInterpretRgba)(
+		a,
+		b,
+		width,
+		height,
+		options.threshold ?? 0.1,
+		options.antialiasing ?? false,
+		output,
+	) as InterpretResult;
+}

--- a/packages/interpret-wasm/tsconfig.json
+++ b/packages/interpret-wasm/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"target": "ES2020",
+		"lib": ["ES2020", "DOM"]
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/interpret-wasm/tsup.config.ts
+++ b/packages/interpret-wasm/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+
+// ESM-only: the wasm-bindgen JS glue uses `import.meta.url` to locate
+// the .wasm sibling. Keep that glue external so its `import.meta.url`
+// stays anchored to `wasm/blazediff_interpret.js` and resolves
+// `blazediff_interpret_bg.wasm` in the same directory — bundling would
+// re-anchor it to dist/.
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: ["esm"],
+	dts: true,
+	splitting: false,
+	sourcemap: false,
+	clean: true,
+	treeshake: true,
+	minify: true,
+	shims: false,
+	external: [/^\.\.\/wasm\//],
+});

--- a/packages/interpret-wasm/vitest.config.mts
+++ b/packages/interpret-wasm/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: "node",
+	},
+});

--- a/packages/interpret-wasm/wasm/blazediff_interpret.d.ts
+++ b/packages/interpret-wasm/wasm/blazediff_interpret.d.ts
@@ -1,0 +1,49 @@
+/* tslint:disable */
+/* eslint-disable */
+export function _start(): void;
+/**
+ * Interpret the pixel diff between two RGBA buffers.
+ *
+ * Returns the `InterpretResult` as a plain JS object — the same shape
+ * `@blazediff/interpret-native` returns, because both serialize the one
+ * `Serialize` derive on the struct.
+ *
+ * If `out_diff` is provided, the diff visualization is written into it
+ * in-place (must be width*height*4 bytes). Pass `null`/`undefined` to skip it;
+ * the diff still needs a scratch buffer internally, but nothing is copied back.
+ */
+export function interpretRgba(rgba_a: Uint8Array, rgba_b: Uint8Array, width: number, height: number, threshold: number, antialiasing: boolean, out_diff?: Uint8Array | null): any;
+
+export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+export interface InitOutput {
+  readonly memory: WebAssembly.Memory;
+  readonly _start: () => void;
+  readonly interpretRgba: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number) => void;
+  readonly __wbindgen_export_0: (a: number, b: number) => number;
+  readonly __wbindgen_export_1: (a: number, b: number, c: number, d: number) => number;
+  readonly __wbindgen_export_2: (a: number, b: number, c: number) => void;
+  readonly __wbindgen_add_to_stack_pointer: (a: number) => number;
+  readonly __wbindgen_start: () => void;
+}
+
+export type SyncInitInput = BufferSource | WebAssembly.Module;
+/**
+* Instantiates the given `module`, which can either be bytes or
+* a precompiled `WebAssembly.Module`.
+*
+* @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+*
+* @returns {InitOutput}
+*/
+export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+
+/**
+* If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+* for everything else, calls `WebAssembly.instantiate` directly.
+*
+* @param {{ module_or_path: InitInput | Promise<InitInput> }} module_or_path - Passing `InitInput` directly is deprecated.
+*
+* @returns {Promise<InitOutput>}
+*/
+export default function __wbg_init (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;

--- a/packages/interpret-wasm/wasm/blazediff_interpret.js
+++ b/packages/interpret-wasm/wasm/blazediff_interpret.js
@@ -1,0 +1,363 @@
+let wasm;
+
+const heap = new Array(128).fill(undefined);
+
+heap.push(undefined, null, true, false);
+
+function getObject(idx) { return heap[idx]; }
+
+let WASM_VECTOR_LEN = 0;
+
+let cachedUint8ArrayMemory0 = null;
+
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+const cachedTextEncoder = (typeof TextEncoder !== 'undefined' ? new TextEncoder('utf-8') : { encode: () => { throw Error('TextEncoder not available') } } );
+
+const encodeString = (typeof cachedTextEncoder.encodeInto === 'function'
+    ? function (arg, view) {
+    return cachedTextEncoder.encodeInto(arg, view);
+}
+    : function (arg, view) {
+    const buf = cachedTextEncoder.encode(arg);
+    view.set(buf);
+    return {
+        read: arg.length,
+        written: buf.length
+    };
+});
+
+function passStringToWasm0(arg, malloc, realloc) {
+
+    if (realloc === undefined) {
+        const buf = cachedTextEncoder.encode(arg);
+        const ptr = malloc(buf.length, 1) >>> 0;
+        getUint8ArrayMemory0().subarray(ptr, ptr + buf.length).set(buf);
+        WASM_VECTOR_LEN = buf.length;
+        return ptr;
+    }
+
+    let len = arg.length;
+    let ptr = malloc(len, 1) >>> 0;
+
+    const mem = getUint8ArrayMemory0();
+
+    let offset = 0;
+
+    for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset);
+        if (code > 0x7F) break;
+        mem[ptr + offset] = code;
+    }
+
+    if (offset !== len) {
+        if (offset !== 0) {
+            arg = arg.slice(offset);
+        }
+        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+        const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+        const ret = encodeString(arg, view);
+
+        offset += ret.written;
+        ptr = realloc(ptr, len, offset, 1) >>> 0;
+    }
+
+    WASM_VECTOR_LEN = offset;
+    return ptr;
+}
+
+let cachedDataViewMemory0 = null;
+
+function getDataViewMemory0() {
+    if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
+        cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
+    }
+    return cachedDataViewMemory0;
+}
+
+let heap_next = heap.length;
+
+function addHeapObject(obj) {
+    if (heap_next === heap.length) heap.push(heap.length + 1);
+    const idx = heap_next;
+    heap_next = heap[idx];
+
+    heap[idx] = obj;
+    return idx;
+}
+
+const cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : { decode: () => { throw Error('TextDecoder not available') } } );
+
+if (typeof TextDecoder !== 'undefined') { cachedTextDecoder.decode(); };
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+function dropObject(idx) {
+    if (idx < 132) return;
+    heap[idx] = heap_next;
+    heap_next = idx;
+}
+
+function takeObject(idx) {
+    const ret = getObject(idx);
+    dropObject(idx);
+    return ret;
+}
+
+export function _start() {
+    wasm._start();
+}
+
+function passArray8ToWasm0(arg, malloc) {
+    const ptr = malloc(arg.length * 1, 1) >>> 0;
+    getUint8ArrayMemory0().set(arg, ptr / 1);
+    WASM_VECTOR_LEN = arg.length;
+    return ptr;
+}
+
+function isLikeNone(x) {
+    return x === undefined || x === null;
+}
+/**
+ * Interpret the pixel diff between two RGBA buffers.
+ *
+ * Returns the `InterpretResult` as a plain JS object — the same shape
+ * `@blazediff/interpret-native` returns, because both serialize the one
+ * `Serialize` derive on the struct.
+ *
+ * If `out_diff` is provided, the diff visualization is written into it
+ * in-place (must be width*height*4 bytes). Pass `null`/`undefined` to skip it;
+ * the diff still needs a scratch buffer internally, but nothing is copied back.
+ * @param {Uint8Array} rgba_a
+ * @param {Uint8Array} rgba_b
+ * @param {number} width
+ * @param {number} height
+ * @param {number} threshold
+ * @param {boolean} antialiasing
+ * @param {Uint8Array | null} [out_diff]
+ * @returns {any}
+ */
+export function interpretRgba(rgba_a, rgba_b, width, height, threshold, antialiasing, out_diff) {
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+        const ptr0 = passArray8ToWasm0(rgba_a, wasm.__wbindgen_export_0);
+        const len0 = WASM_VECTOR_LEN;
+        const ptr1 = passArray8ToWasm0(rgba_b, wasm.__wbindgen_export_0);
+        const len1 = WASM_VECTOR_LEN;
+        wasm.interpretRgba(retptr, ptr0, len0, ptr1, len1, width, height, threshold, antialiasing, isLikeNone(out_diff) ? 0 : addHeapObject(out_diff));
+        var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+        var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+        if (r2) {
+            throw takeObject(r1);
+        }
+        return takeObject(r0);
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16);
+    }
+}
+
+async function __wbg_load(module, imports) {
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports);
+
+            } catch (e) {
+                if (module.headers.get('Content-Type') != 'application/wasm') {
+                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+
+                } else {
+                    throw e;
+                }
+            }
+        }
+
+        const bytes = await module.arrayBuffer();
+        return await WebAssembly.instantiate(bytes, imports);
+
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports);
+
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module };
+
+        } else {
+            return instance;
+        }
+    }
+}
+
+function __wbg_get_imports() {
+    const imports = {};
+    imports.wbg = {};
+    imports.wbg.__wbg_String_8f0eb39a4a4c2f66 = function(arg0, arg1) {
+        const ret = String(getObject(arg1));
+        const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_export_0, wasm.__wbindgen_export_1);
+        const len1 = WASM_VECTOR_LEN;
+        getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+        getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    imports.wbg.__wbg_buffer_609cc3eee51ed158 = function(arg0) {
+        const ret = getObject(arg0).buffer;
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_error_7534b8e9a36f1ab4 = function(arg0, arg1) {
+        let deferred0_0;
+        let deferred0_1;
+        try {
+            deferred0_0 = arg0;
+            deferred0_1 = arg1;
+            console.error(getStringFromWasm0(arg0, arg1));
+        } finally {
+            wasm.__wbindgen_export_2(deferred0_0, deferred0_1, 1);
+        }
+    };
+    imports.wbg.__wbg_length_a446193dc22c12f8 = function(arg0) {
+        const ret = getObject(arg0).length;
+        return ret;
+    };
+    imports.wbg.__wbg_new_405e22f390576ce2 = function() {
+        const ret = new Object();
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_new_78feb108b6472713 = function() {
+        const ret = new Array();
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_new_8a6f238a6ece86ea = function() {
+        const ret = new Error();
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_newwithbyteoffsetandlength_d97e637ebe145a9a = function(arg0, arg1, arg2) {
+        const ret = new Uint8Array(getObject(arg0), arg1 >>> 0, arg2 >>> 0);
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_set_37837023f3d740e8 = function(arg0, arg1, arg2) {
+        getObject(arg0)[arg1 >>> 0] = takeObject(arg2);
+    };
+    imports.wbg.__wbg_set_3f1d0b984ed272ed = function(arg0, arg1, arg2) {
+        getObject(arg0)[takeObject(arg1)] = takeObject(arg2);
+    };
+    imports.wbg.__wbg_set_65595bdd868b3009 = function(arg0, arg1, arg2) {
+        getObject(arg0).set(getObject(arg1), arg2 >>> 0);
+    };
+    imports.wbg.__wbg_stack_0ed75d68575b0f3c = function(arg0, arg1) {
+        const ret = getObject(arg1).stack;
+        const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_export_0, wasm.__wbindgen_export_1);
+        const len1 = WASM_VECTOR_LEN;
+        getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+        getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    imports.wbg.__wbindgen_bigint_from_u64 = function(arg0) {
+        const ret = BigInt.asUintN(64, arg0);
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbindgen_error_new = function(arg0, arg1) {
+        const ret = new Error(getStringFromWasm0(arg0, arg1));
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbindgen_memory = function() {
+        const ret = wasm.memory;
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbindgen_number_new = function(arg0) {
+        const ret = arg0;
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbindgen_object_clone_ref = function(arg0) {
+        const ret = getObject(arg0);
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbindgen_object_drop_ref = function(arg0) {
+        takeObject(arg0);
+    };
+    imports.wbg.__wbindgen_string_new = function(arg0, arg1) {
+        const ret = getStringFromWasm0(arg0, arg1);
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbindgen_throw = function(arg0, arg1) {
+        throw new Error(getStringFromWasm0(arg0, arg1));
+    };
+
+    return imports;
+}
+
+function __wbg_init_memory(imports, memory) {
+
+}
+
+function __wbg_finalize_init(instance, module) {
+    wasm = instance.exports;
+    __wbg_init.__wbindgen_wasm_module = module;
+    cachedDataViewMemory0 = null;
+    cachedUint8ArrayMemory0 = null;
+
+
+    wasm.__wbindgen_start();
+    return wasm;
+}
+
+function initSync(module) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (typeof module !== 'undefined') {
+        if (Object.getPrototypeOf(module) === Object.prototype) {
+            ({module} = module)
+        } else {
+            console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+        }
+    }
+
+    const imports = __wbg_get_imports();
+
+    __wbg_init_memory(imports);
+
+    if (!(module instanceof WebAssembly.Module)) {
+        module = new WebAssembly.Module(module);
+    }
+
+    const instance = new WebAssembly.Instance(module, imports);
+
+    return __wbg_finalize_init(instance, module);
+}
+
+async function __wbg_init(module_or_path) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (typeof module_or_path !== 'undefined') {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
+    }
+
+    if (typeof module_or_path === 'undefined') {
+        module_or_path = new URL('blazediff_interpret_bg.wasm', import.meta.url);
+    }
+    const imports = __wbg_get_imports();
+
+    if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
+        module_or_path = fetch(module_or_path);
+    }
+
+    __wbg_init_memory(imports);
+
+    const { instance, module } = await __wbg_load(await module_or_path, imports);
+
+    return __wbg_finalize_init(instance, module);
+}
+
+export { initSync };
+export default __wbg_init;

--- a/packages/interpret-wasm/wasm/blazediff_interpret_bg.wasm.d.ts
+++ b/packages/interpret-wasm/wasm/blazediff_interpret_bg.wasm.d.ts
@@ -1,0 +1,10 @@
+/* tslint:disable */
+/* eslint-disable */
+export const memory: WebAssembly.Memory;
+export const _start: () => void;
+export const interpretRgba: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number) => void;
+export const __wbindgen_export_0: (a: number, b: number) => number;
+export const __wbindgen_export_1: (a: number, b: number, c: number, d: number) => number;
+export const __wbindgen_export_2: (a: number, b: number, c: number) => void;
+export const __wbindgen_add_to_stack_pointer: (a: number) => number;
+export const __wbindgen_start: () => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@blazediff/interpret-native':
         specifier: workspace:*
         version: link:../../packages/interpret-native/interpret-native
+      '@blazediff/interpret-wasm':
+        specifier: workspace:*
+        version: link:../../packages/interpret-wasm
       '@blazediff/object':
         specifier: workspace:*
         version: link:../../packages/object
@@ -652,6 +655,30 @@ importers:
   packages/interpret-native/interpret-native-win32-arm64: {}
 
   packages/interpret-native/interpret-native-win32-x64: {}
+
+  packages/interpret-wasm:
+    devDependencies:
+      '@blazediff/interpret-native':
+        specifier: workspace:*
+        version: link:../interpret-native/interpret-native
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.0
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
+      tsup:
+        specifier: 8.5.0
+        version: 8.5.0(jiti@2.6.0)(postcss@8.5.15)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.6.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/jest:
     dependencies:

--- a/scripts/release/changed-artifacts.js
+++ b/scripts/release/changed-artifacts.js
@@ -17,6 +17,13 @@
 //   interpret  interpret .node            blazediff-interpret, blazediff, blazediff-ssim,
 //                                         blazediff-shared, blazediff-png
 //   wasm       core wasm module           blazediff, blazediff-shared (built without codecs)
+//   wasm_interpret
+//              interpret wasm module      blazediff-interpret, blazediff, blazediff-ssim,
+//                                         blazediff-shared (built without codecs)
+//
+// Family keys are shell identifiers: this script's output is `eval`'d in
+// release-artifacts-check.yml and `tee`'d into $GITHUB_OUTPUT, so a hyphen
+// would break the eval silently. Underscores only.
 //
 // Wheels are deliberately not families of their own: each of the three sets
 // (blazediff / blazediff-ssim / blazediff-interpret) is built from the crate a
@@ -43,7 +50,7 @@ const path = require("node:path");
 
 const ROOT = path.resolve(__dirname, "..", "..");
 
-const FAMILIES = ["core", "ssim", "interpret", "wasm"];
+const FAMILIES = ["core", "ssim", "interpret", "wasm", "wasm_interpret"];
 
 /** The crate sources compiled into each family's artifacts. */
 const FAMILY_CRATES = {
@@ -59,6 +66,12 @@ const FAMILY_CRATES = {
 	// blazediff-shared's `codecs` feature (and blazediff-png with it) is off
 	// in the wasm build.
 	wasm: ["blazediff", "blazediff-shared"],
+	wasm_interpret: [
+		"blazediff-interpret",
+		"blazediff",
+		"blazediff-ssim",
+		"blazediff-shared",
+	],
 };
 
 /** The npm package whose changesets tag anchors each family's last release. */
@@ -67,6 +80,7 @@ const FAMILY_NPM = {
 	ssim: "@blazediff/ssim-native",
 	interpret: "@blazediff/interpret-native",
 	wasm: "@blazediff/core-wasm",
+	wasm_interpret: "@blazediff/interpret-wasm",
 };
 
 const FAMILY_PACKAGE = {
@@ -74,6 +88,7 @@ const FAMILY_PACKAGE = {
 	ssim: "packages/ssim-native/ssim-native/package.json",
 	interpret: "packages/interpret-native/interpret-native/package.json",
 	wasm: "packages/core-wasm/package.json",
+	wasm_interpret: "packages/interpret-wasm/package.json",
 };
 
 const ALL_CRATES = [...new Set(Object.values(FAMILY_CRATES).flat())];

--- a/scripts/release/restore-artifacts.js
+++ b/scripts/release/restore-artifacts.js
@@ -54,7 +54,17 @@ const TARGETS = [
 	"aarch64-pc-windows-msvc",
 	"x86_64-pc-windows-msvc",
 ];
-const WASM_ARTIFACT = "wasm";
+// The wasm packages, keyed by the artifact name build-artifacts.yml uploads.
+// Each archive is rooted at its wasm directory rather than the repo root, so
+// the destination is spelled out here.
+const WASM_FAMILIES = [
+	{ artifact: "wasm", family: "wasm", pkg: "core-wasm" },
+	{
+		artifact: "interpret-wasm",
+		family: "wasm_interpret",
+		pkg: "interpret-wasm",
+	},
+];
 // One committed wheels dir per PyPI distribution, each named after its crate.
 const WHEELS_DIRS = [
 	path.join("crates", "blazediff", "wheels"),
@@ -87,7 +97,9 @@ function familyOf(relative) {
 	if (relative.startsWith("packages/ssim-native/ssim-native-")) return "ssim";
 	if (relative.startsWith("packages/interpret-native/interpret-native-"))
 		return "interpret";
-	if (relative.startsWith(path.join("packages", "core-wasm"))) return "wasm";
+	for (const { family, pkg } of WASM_FAMILIES) {
+		if (relative.startsWith(path.join("packages", pkg))) return family;
+	}
 	if (WHEELS_DIRS.some((dir) => relative.startsWith(dir))) return "wheels";
 	return null;
 }
@@ -185,7 +197,11 @@ function usableArtifacts(slug, runId) {
 		const expired = artifacts.some((artifact) => artifact.expired);
 		return { ok: false, missing, expired };
 	}
-	return { ok: true, artifacts: live, hasWasm: names.has(WASM_ARTIFACT) };
+	const wasm = {};
+	for (const { family, artifact } of WASM_FAMILIES) {
+		wasm[family] = names.has(artifact);
+	}
+	return { ok: true, artifacts: live, wasm };
 }
 
 function download(slug, runId, dir, name = null) {
@@ -244,9 +260,10 @@ function applyArtifacts(stagingDir, needed) {
 		}
 	}
 
-	const wasmSource = path.join(stagingDir, WASM_ARTIFACT);
-	const wasmDest = path.join("packages", "core-wasm", "wasm");
-	if (fs.existsSync(wasmSource)) {
+	for (const { artifact, pkg } of WASM_FAMILIES) {
+		const wasmSource = path.join(stagingDir, artifact);
+		if (!fs.existsSync(wasmSource)) continue;
+		const wasmDest = path.join("packages", pkg, "wasm");
 		for (const relative of walk(wasmSource)) {
 			apply(
 				path.join(wasmSource, relative),
@@ -299,12 +316,20 @@ function verify(restored) {
 	}
 }
 
+/** " (no wasm, no interpret-wasm)" — or "" when a run carries them all. */
+function missingWasmLabel(state) {
+	const absent = WASM_FAMILIES.filter(({ family }) => !state.wasm[family]).map(
+		({ artifact }) => `no ${artifact}`,
+	);
+	return absent.length > 0 ? ` (${absent.join(", ")})` : "";
+}
+
 function listRuns(slug) {
 	console.log(`Recent successful ${WORKFLOW} runs:\n`);
 	for (const run of successfulRuns(slug)) {
 		const state = usableArtifacts(slug, run.id);
 		const status = state.ok
-			? `artifacts available${state.hasWasm ? "" : " (no wasm)"}`
+			? `artifacts available${missingWasmLabel(state)}`
 			: state.expired
 				? "artifacts expired"
 				: `incomplete (missing ${state.missing.join(", ")})`;
@@ -347,9 +372,12 @@ function main() {
 				);
 				continue;
 			}
-			if (needed.wasm && !state.hasWasm) {
+			const staleWasm = WASM_FAMILIES.find(
+				({ family }) => needed[family] && !state.wasm[family],
+			);
+			if (staleWasm) {
 				rejected.push(
-					`  run ${run.id} — has no wasm artifact, but the wasm sources changed`,
+					`  run ${run.id} — has no ${staleWasm.artifact} artifact, but the ${staleWasm.artifact} sources changed`,
 				);
 				continue;
 			}


### PR DESCRIPTION
**What:** The Image Difference Analysis demo loses its `Demo` heading, gains a full-width select over 18 fixture pairs, and computes results in the browser via a new `@blazediff/interpret-wasm` package.

**Why:** The demo showed one hardcoded pair and a JSON blob baked at build time by `interpret-native` — nothing on the page actually ran.

**How:** A `wasm` feature on `blazediff-interpret` (which required making image I/O an optional `io` feature so the wasm links none of the vendored C), plus a Web Worker that decodes the pair and calls the classifier; the module loads from jsDelivr, pinned to the workspace version.

**Notes:**
- **Needs `/build`** — `packages/interpret-wasm/wasm/blazediff_interpret_bg.wasm` is deliberately not committed (see `check-no-binaries.sh`), and the interpret `.node` files are now stale against the determinism fix below.
- **Needs an npm trusted publisher** for `@blazediff/interpret-wasm` before the first release. The demo 404s gracefully (clear error + Retry) until that publish lands.
- Fixes a real determinism bug the new parity test caught: `extract_labeled_regions` iterated a `HashMap`, so regions with equal `pixelCount` came back in a per-process random order — leaking into `regions` and the summary text, contradicting the documented "It is deterministic". Now a `BTreeMap`, with a regression test.
- Fixes the severity pill, which keyed on `Low`/`Medium`/`High` while serde emits kebab-case, so it always fell through to gray.
- `llms.txt` is regenerated and sweeps in pre-existing drift (SSIM numbers, interpret pipeline wording) that main never regenerated. Happy to drop those hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)